### PR TITLE
Improve method Edge::build and add method to evaluate the error value of a config

### DIFF
--- a/include/hpp/manipulation/graph/graph.hh
+++ b/include/hpp/manipulation/graph/graph.hh
@@ -98,6 +98,20 @@ namespace hpp {
 	  bool getConfigErrorForNode (ConfigurationIn_t config,
 				      const NodePtr_t& node, vector_t& error);
 
+	  /// Get error of a config with respect to an edge constraint
+	  ///
+	  /// \param config Configuration,
+	  /// \param edge edge containing the constraint to check config against
+	  /// \retval error the error of the edge constraint for the
+	  ///         configuration
+	  /// \return whether the configuration can be a start point of a path
+	  //          of the edge
+	  /// Call core::ConfigProjector::rightHandSideFromConfig with
+	  /// input configuration and method core::ConstraintSet::isSatisfied
+	  /// for the edge constraint.
+	  bool getConfigErrorForEdge (ConfigurationIn_t config,
+				      const EdgePtr_t& edge, vector_t& error);
+
           /// Constraint to project a path.
           /// \param edge a list of edges defining the foliation.
           /// \return The constraint.

--- a/src/graph/edge.cc
+++ b/src/graph/edge.cc
@@ -281,26 +281,33 @@ namespace hpp {
 			ConfigurationIn_t q2)
 	const
       {
-        ConstraintSetPtr_t constraints = pathConstraint ();
-        constraints->configProjector ()->rightHandSideFromConfig(q1);
-        if (constraints->isSatisfied (q1)) {
-          if (constraints->isSatisfied (q2)) {
-            path = (*steeringMethod_->get()) (q1, q2);
-            return (bool)path;
-          }
-          hppDout(info, "q2 does not satisfy the constraints");
-        }
 	core::SteeringMethodPtr_t sm (steeringMethod_->get());
 	if (!sm) {
 	  buildPathConstraint ();
 	}
+	sm = (steeringMethod_->get());
 	if (!sm) {
 	  std::ostringstream oss;
 	  oss << "No steering method set in edge " << name () << ".";
 	  throw std::runtime_error (oss.str ().c_str ());
 	}
-	path = (*sm) (q1, q2);
-        return path;
+        ConstraintSetPtr_t constraints = pathConstraint ();
+        constraints->configProjector ()->rightHandSideFromConfig(q1);
+        if (constraints->isSatisfied (q1)) {
+          if (constraints->isSatisfied (q2)) {
+            path = (*sm) (q1, q2);
+            return (bool)path;
+          } else {
+	    hppDout(info, "q2 does not satisfy the constraints");
+	    return false;
+	  }
+        } else {
+	  std::ostringstream oss;
+	  oss << "The initial configuration does not satisfy the constraints of"
+	    " edge " << name () << "." << std::endl;
+	  oss << "The graph is probably malformed";
+	  throw std::runtime_error (oss.str ().c_str ());
+	}
       }
 
       bool Edge::applyConstraints (core::NodePtr_t nnear, ConfigurationOut_t q) const

--- a/src/graph/graph.cc
+++ b/src/graph/graph.cc
@@ -122,6 +122,15 @@ namespace hpp {
 	return configConstraint (node)->isSatisfied (config, error);
       }
 
+      bool Graph::getConfigErrorForEdge (ConfigurationIn_t config,
+					 const EdgePtr_t& edge, vector_t& error)
+      {
+	ConstraintSetPtr_t cs (pathConstraint (edge));
+	ConfigProjectorPtr_t cp (cs->configProjector ());
+	if (cp) cp->rightHandSideFromConfig (config);
+	return cs->isSatisfied (config, error);
+      }
+
       ConstraintSetPtr_t Graph::configConstraint (const EdgePtr_t& edge)
       {
         return edge->configConstraint ();


### PR DESCRIPTION
    Improve method edge::build
    
      - throw if initial configuration does not satisfy the constraint,
      - build steering method is required before building path.

    Add a method to compute the error value of a config wrt an edge constraint
    
      - the method calls rightHandSideFromConfig with the input configuration and
      - isSatisfied to get the error vector.
