### PR TITLE
Move lockedJointPtr_t to hpp-core in hpp::manipulation::ProblemSolver

### DIFF
--- a/include/hpp/manipulation/fwd.hh
+++ b/include/hpp/manipulation/fwd.hh
@@ -121,9 +121,10 @@ namespace hpp {
 
     typedef std::list < NumericalConstraintPtr_t > NumericalConstraints_t;
 
-    typedef std::vector<core::vector3_t> Shape_t;
-    typedef std::pair <JointPtr_t, Shape_t> JointAndShape_t;
-    typedef std::list <JointAndShape_t> JointAndShapes_t;
+    typedef core::Shape_t Shape_t;
+    typedef core::JointAndShape_t JointAndShape_t;
+    typedef core::JointAndShapes_t JointAndShapes_t;
+
     typedef std::list <std::string> StringList_t;
 
     namespace pathOptimization {

--- a/include/hpp/manipulation/problem-solver.hh
+++ b/include/hpp/manipulation/problem-solver.hh
@@ -30,13 +30,9 @@
 namespace hpp {
   namespace manipulation {
     class HPP_MANIPULATION_DLLAPI ProblemSolver :
-      public core::ProblemSolver,
-      public core::Containers <
-        boost::mpl::vector <LockedJointPtr_t, JointAndShapes_t> >
+      public core::ProblemSolver
     {
       public:
-        typedef core::Containers < boost::mpl::vector
-          <LockedJointPtr_t, JointAndShapes_t> > ThisC_t;
         typedef core::ProblemSolver parent_t;
         typedef std::vector <std::string> Names_t;
 

--- a/src/graph/helper.cc
+++ b/src/graph/helper.cc
@@ -1080,7 +1080,7 @@ namespace hpp {
               LockedJointPtr_t lj = core::LockedJoint::create (oj,
                   robot.currentConfiguration()
                   .segment (oj->rankInConfiguration (), oj->configSize ()));
-              ps->ProblemSolver::ThisC_t::add <LockedJointPtr_t> ("lock_" + oj->name (), lj);
+              ps->add <LockedJointPtr_t> ("lock_" + oj->name (), lj);
               objects[i].get<0> ().get<2> ().push_back (lj);
             }
             ++i;

--- a/src/problem-solver.cc
+++ b/src/problem-solver.cc
@@ -33,7 +33,7 @@
 #include <hpp/core/path-projector/global.hh>
 #include <hpp/core/path-projector/recursive-hermite.hh>
 #include <hpp/core/roadmap.hh>
-#include <hpp/core/steering-method-straight.hh>
+#include <hpp/core/steering-method/straight.hh>
 #include <hpp/core/comparison-type.hh>
 
 #include "hpp/manipulation/package-config.hh" // HPP_MANIPULATION_HAS_WHOLEBODY_STEP
@@ -217,8 +217,8 @@ namespace hpp {
         if (robot_->has <JointAndShapes_t> (*it2))
           l = robot_->get <JointAndShapes_t> (*it2);
         // and then environment triangles.
-        else if (ThisC_t::has <JointAndShapes_t> (*it2))
-          l = ThisC_t::get <JointAndShapes_t> (*it2);
+        else if (core::ProblemSolver::has <JointAndShapes_t> (*it2))
+          l = core::ProblemSolver::get <JointAndShapes_t> (*it2);
         else throw std::runtime_error ("Second list of triangles not found.");
         for (JointAndShapes_t::const_iterator it = l.begin ();
             it != l.end(); ++it) {
@@ -265,8 +265,8 @@ namespace hpp {
         if (robot_->has <JointAndShapes_t> (*it2))
           l = robot_->get <JointAndShapes_t> (*it2);
         // and then environment triangles.
-        else if (ThisC_t::has <JointAndShapes_t> (*it2))
-          l = ThisC_t::get <JointAndShapes_t> (*it2);
+        else if (has <JointAndShapes_t> (*it2))
+          l = get <JointAndShapes_t> (*it2);
         else throw std::runtime_error ("Second list of triangles not found.");
 
         for (JointAndShapes_t::const_iterator it = l.begin ();


### PR DESCRIPTION
  Thus locked joints can be handled in hpp-corbaserver instead of hpp-manipulation-corba.