### PR TITLE
In WaypointEdge, do not create paths between 2 successive equal confi…

### DIFF
--- a/src/graph/edge.cc
+++ b/src/graph/edge.cc
@@ -430,14 +430,17 @@ namespace hpp {
             lastSucceeded_ = false;
             return false;
           }
-          if (!edges_[i]->build (p, configs_.col(i), configs_.col (i+1))) {
-            hppDout (info, "Waypoint edge " << name() << ": build failed at waypoint " << i << "."
-                << "\nUse cache: " << useCache
-                );
-            lastSucceeded_ = false;
-            return false;
+          if (configs_.col(i) != configs_.col (i+1)) {
+            assert ((configs_.col(i) - configs_.col (i+1)).norm () > 1e-8);
+            if (!edges_[i]->build (p, configs_.col(i), configs_.col (i+1))) {
+              hppDout (info, "Waypoint edge " << name()
+                       << ": build failed at waypoint " << i << "."
+                       << "\nUse cache: " << useCache);
+              lastSucceeded_ = false;
+              return false;
+            }
+            pv->appendPath (p);
           }
-          pv->appendPath (p);
         }
 
         path = pv;


### PR DESCRIPTION
…gurations

  - assert that if not equal, distance between 2 successive configuration is
    more than 1e-8.
  - this complies with hpp-core policy acording to which, a constraint does
    not modify a configuration if the configuration satisfies the constraint.