### PR TITLE
Fix mask vector when creating grasp on non-freeflyer

### DIFF
--- a/src/handle.cc
+++ b/src/handle.cc
@@ -189,7 +189,7 @@ namespace hpp {
       return constraints::implicit::RelativePose::create
         (n, robot (), gripper->joint (), joint (),
          gripper->objectPositionInJoint (), localPosition(),
-         std::vector <bool> (true, 6), comp);
+         std::vector <bool> (6, true), comp);
     }
 
     ImplicitPtr_t Handle::createPreGrasp


### PR DESCRIPTION
By fixing the order of the parameters in std::vector initialization.