### PR TITLE
Add GraphPathValidation::setSecurityMarginBetweenBodies

### DIFF
--- a/include/hpp/manipulation/device.hh
+++ b/include/hpp/manipulation/device.hh
@@ -64,6 +64,9 @@ namespace hpp {
 
         FrameIndices_t robotFrames (const std::string& robotName) const;
 
+        void removeJoints(const std::vector<std::string>& jointNames,
+            Configuration_t referenceConfig);
+
         core::Container <HandlePtr_t> handles;
         core::Container <GripperPtr_t> grippers;
         core::Container <JointAndShapes_t> jointAndShapes;

--- a/include/hpp/manipulation/graph-path-validation.hh
+++ b/include/hpp/manipulation/graph-path-validation.hh
@@ -150,6 +150,21 @@ namespace hpp {
           if (oui) oui->setSecurityMargins(securityMargins);
         }
 
+        /// \copydoc hpp::core::ObstacleUserInterface::setSecurityMarginBetweenBodies
+        ///
+        /// Dynamic cast inner path validation into
+        /// hpp::core::ObstacleUserInterface and calls
+        /// hpp::core::ObstacleUserInterface::setSecurityMargins in case of
+        /// success.
+        void setSecurityMarginBetweenBodies(const std::string& body_a,
+                                            const std::string& body_b,
+                                            const value_type& margin)
+        {
+          shared_ptr<core::ObstacleUserInterface> oui =
+            HPP_DYNAMIC_PTR_CAST(core::ObstacleUserInterface, pathValidation_);
+          if (oui) oui->setSecurityMarginBetweenBodies(body_a, body_b, margin);
+        }
+
       protected:
         /// Constructor
         GraphPathValidation (const PathValidationPtr_t& pathValidation);

--- a/include/hpp/manipulation/path-optimization/enforce-transition-semantic.hh
+++ b/include/hpp/manipulation/path-optimization/enforce-transition-semantic.hh
@@ -38,6 +38,7 @@ namespace hpp {
 
           static Ptr_t create (const core::ProblemConstPtr_t& problem) {
             ProblemConstPtr_t p (HPP_DYNAMIC_PTR_CAST(const Problem, problem));
+            if (!p) throw std::invalid_argument("This is not a manipulation problem.");
             return Ptr_t (new EnforceTransitionSemantic (p));
           }
 

--- a/src/device.cc
+++ b/src/device.cc
@@ -124,6 +124,16 @@ namespace hpp {
       return frameIndices;
     }
 
+    void Device::removeJoints(const std::vector<std::string>& jointNames,
+        Configuration_t referenceConfig)
+    {
+      Parent_t::removeJoints(jointNames, referenceConfig);
+
+      for (auto& pair : grippers.map)
+        pair.second = pinocchio::Gripper::create(pair.second->name(), self_);
+      // TODO update handles and jointAndShapes
+    }
+
     std::ostream& Device::print (std::ostream& os) const
     {
       Parent_t::print (os);

--- a/src/path-optimization/spline-gradient-based.cc
+++ b/src/path-optimization/spline-gradient-based.cc
@@ -50,7 +50,8 @@ namespace hpp {
       typename SplineGradientBased<_PB, _SO>::Ptr_t SplineGradientBased<_PB, _SO>::createFromCore
       (const core::ProblemConstPtr_t& problem)
       {
-        assert(HPP_DYNAMIC_PTR_CAST(const Problem, problem));
+        if (!HPP_DYNAMIC_PTR_CAST(const Problem, problem))
+          throw std::invalid_argument("This is not a manipulation problem.");
         return create (HPP_STATIC_PTR_CAST(const Problem, problem));
       }
 


### PR DESCRIPTION
- Reimplement Device::removeJoints (some work is missing)
- Add GraphPathValidation::setSecurityMarginBetweenBodies

The first commit is not mandatory and provides partially implemented code. I can remove it if it is judged too preliminary.
