### PR TITLE
Fix steeringMethod::CrossStateOptimization

### DIFF
--- a/include/hpp/manipulation/graph/graph.hh
+++ b/include/hpp/manipulation/graph/graph.hh
@@ -81,6 +81,10 @@ namespace hpp {
           /// Select randomly outgoing edge of the given node.
           EdgePtr_t chooseEdge(RoadmapNodePtr_t node) const;
 
+          /// Clear the vector of constraints and complements
+          /// \sa registerConstraints
+          void clearConstraintsAndComplement();
+
           /// Register a triple of constraints to be inserted in nodes and edges
           /// \param constraint a constraint (grasp of placement)
           /// \param complement the complement constraint

--- a/src/graph/graph.cc
+++ b/src/graph/graph.cc
@@ -56,7 +56,6 @@ namespace hpp {
         assert(components_.size() >= 1 && components_[0].lock() == wkPtr_.lock());
         for (std::size_t i = 1; i < components_.size(); ++i)
           components_[i].lock()->initialize();
-        constraintsAndComplements_.clear ();
         isInit_ = true;
       }
 
@@ -151,6 +150,11 @@ namespace hpp {
       EdgePtr_t Graph::chooseEdge (RoadmapNodePtr_t from) const
       {
         return stateSelector_->chooseEdge (from);
+      }
+
+      void Graph::clearConstraintsAndComplement()
+      {
+        constraintsAndComplements_.clear();
       }
 
       void Graph::registerConstraints

--- a/src/problem-solver.cc
+++ b/src/problem-solver.cc
@@ -221,6 +221,7 @@ namespace hpp {
       if (!constraintGraph_)
         throw std::runtime_error ("The graph is not defined.");
       initSteeringMethod();
+      constraintGraph_->clearConstraintsAndComplement();
       for (std::size_t i = 0; i < constraintsAndComplements.size(); ++i) {
         const ConstraintAndComplement_t& c = constraintsAndComplements[i];
         constraintGraph ()->registerConstraints (c.constraint, c.complement, c.both);

--- a/src/steering-method/cross-state-optimization.cc
+++ b/src/steering-method/cross-state-optimization.cc
@@ -322,9 +322,9 @@ namespace hpp {
       (OptimizationData& d, size_type index) const
       {
         const ImplicitPtr_t c (constraints_ [index]);
-        LiegroupElement rhsInit;
+        LiegroupElement rhsInit(c->function().outputSpace());
         c->rightHandSideFromConfig (d.q1, rhsInit);
-        LiegroupElement rhsGoal;
+        LiegroupElement rhsGoal(c->function().outputSpace());
         c->rightHandSideFromConfig (d.q2, rhsGoal);
         // Check that right hand sides are close to each other
         value_type eps (problem_->constraintGraph ()->errorThreshold ());


### PR DESCRIPTION
  - allow user to initialize waypoint solvers with random configuration (via Problem::Parameter),
  - take into account constraints and complements to insert explicit constraints when possible,
  - do not copy constraints anymore.