### PR TITLE
[ProblemSolver] Allow non-graph steering method in createPathProjector

### DIFF
--- a/src/problem-solver.cc
+++ b/src/problem-solver.cc
@@ -105,8 +105,8 @@ core::PathProjectorPtr_t createPathProjector(
   steeringMethod::GraphPtr_t gsm =
       HPP_DYNAMIC_PTR_CAST(steeringMethod::Graph, problem->steeringMethod());
   if (!gsm)
-    return PathProjectorType::create (problem->distance(),
-        problem->steeringMethod(), step);
+    return PathProjectorType::create(problem->distance(),
+                                     problem->steeringMethod(), step);
   return PathProjectorType::create(problem->distance(),
                                    gsm->innerSteeringMethod(), step);
 }

--- a/src/problem-solver.cc
+++ b/src/problem-solver.cc
@@ -105,9 +105,8 @@ core::PathProjectorPtr_t createPathProjector(
   steeringMethod::GraphPtr_t gsm =
       HPP_DYNAMIC_PTR_CAST(steeringMethod::Graph, problem->steeringMethod());
   if (!gsm)
-    throw std::logic_error(
-        "The steering method should be of type"
-        " steeringMethod::Graph");
+    return PathProjectorType::create (problem->distance(),
+        problem->steeringMethod(), step);
   return PathProjectorType::create(problem->distance(),
                                    gsm->innerSteeringMethod(), step);
 }


### PR DESCRIPTION
  Path projectors are defined in core::ProblemSolver and overloaded in
  manipulation::ProblemSolver. Formerly, the overloaded method checked that
  the steering method was of type manipulation::SteeringMethod and created
  the path projector with the inner steering of the latter.

  This commit modifies this behavior since calling idl method
  hpp::corbaserver::Problem::createPathPlanner with a core_idl::Problem
  instance as input fails when the problem solver is of type
  manipulation::ProblemSolver.