### PR TITLE
Device::setRobotRootPosition invalidates all the device data.

### DIFF
--- a/src/device.cc
+++ b/src/device.cc
@@ -86,6 +86,8 @@ void Device::setRobotRootPosition(const std::string& rn, const Transform3f& t) {
     }
   }
   invalidate();
+  // Update the pool of device data.
+  numberDeviceData(numberDeviceData());
 }
 
 std::vector<std::string> Device::robotNames() const {


### PR DESCRIPTION
Without this change, the device data in the pool used by the multi-threaded API are not invalidated.