### PR TITLE
Add feature discard non-solvable potential solution on SPF

### DIFF
--- a/include/hpp/manipulation/path-planner/states-path-finder.hh
+++ b/include/hpp/manipulation/path-planner/states-path-finder.hh
@@ -194,26 +194,31 @@ class HPP_MANIPULATION_DLLAPI StatesPathFinder : public core::PathPlanner {
   /// Step 4 of the algorithm
   void preInitializeRHS(std::size_t j, Configuration_t& q);
   bool analyseOptimizationProblem(const graph::Edges_t& transitions,
-                                   core::ProblemConstPtr_t _problem);
+                                  core::ProblemConstPtr_t _problem);
 
   /// Step 5 of the algorithm
   void initializeRHS(std::size_t j);
   bool solveOptimizationProblem();
 
-  // Data structure used to store a constraint right hand side as value and its name as key, both in form
-  // of hash numbers (so that names and rhs of two constraints can be easily merge).
-  // Exemple : ConstraintMap_t map = {{nameStringHash, rhsVectorHash}};
-  // With rhsVectorHash the hash of a vector_t of rights hand side constraints with hashRHS, and nameStringHash 
+  // Data structure used to store a constraint right hand side as value and its
+  // name as key, both in form of hash numbers (so that names and rhs of two
+  // constraints can be easily merge). Exemple : ConstraintMap_t map =
+  // {{nameStringHash, rhsVectorHash}}; With rhsVectorHash the hash of a
+  // vector_t of rights hand side constraints with hashRHS, and nameStringHash
   // the hash of a std::string - obtained for instance with std::hash.
-  typedef std::unordered_map<size_t, size_t> ConstraintMap_t; //map (name, rhs)
-  
-  /// @brief Get a configuration in accordance with the statuts matrix at a step j for the constraint i
+  typedef std::unordered_map<size_t, size_t> ConstraintMap_t;  // map (name,
+                                                               // rhs)
+
+  /// @brief Get a configuration in accordance with the statuts matrix at a step
+  /// j for the constraint i
   /// @param i number of the constraint in the status matrix
   /// @param j step of the potential solution (index of a waypoint)
-  /// @return a configuration Configuration_t which follows the status matrix indication at the given indices
+  /// @return a configuration Configuration_t which follows the status matrix
+  /// indication at the given indices
   Configuration_t getConfigStatus(size_type i, size_type j) const;
 
-  /// @brief Get the right hand side of a constraint w.r.t a set configuration for this constraint
+  /// @brief Get the right hand side of a constraint w.r.t a set configuration
+  /// for this constraint
   /// @param constraint the constraint to compute the right hand side of
   /// @param q the configuration in which the constraint is set
   /// @return a right hand side vector_t
@@ -224,18 +229,26 @@ class HPP_MANIPULATION_DLLAPI StatesPathFinder : public core::PathPlanner {
   /// @return a size_t integer hash
   size_t hashRHS(vector_t rhs) const;
 
-  /// @brief Check if a solution (a list of transition) contains impossible to solve steps due to inevitable collisions
-  /// @param pairMap The ConstraintMap_tf table of pairs of incompatibles constraints
+  /// @brief Check if a solution (a list of transition) contains impossible to
+  /// solve steps due to inevitable collisions
+  /// @param pairMap The ConstraintMap_tf table of pairs of incompatibles
+  /// constraints
   /// @param constraintMap The hasmap table of constraints which are in pairMap
-  /// @return a bool which is true is there is no impossible to solve steps, true otherwise
-  bool checkSolvers(ConstraintMap_t const & pairMap, ConstraintMap_t const & constraintMap) const;
+  /// @return a bool which is true is there is no impossible to solve steps,
+  /// true otherwise
+  bool checkSolvers(ConstraintMap_t const& pairMap,
+                    ConstraintMap_t const& constraintMap) const;
 
-  /// @brief For a certain step wp during solving check for collision impossible to solve.
-  /// @param pairMap The ConstraintMap_t table of pairs of incompatibles constraints
+  /// @brief For a certain step wp during solving check for collision impossible
+  /// to solve.
+  /// @param pairMap The ConstraintMap_t table of pairs of incompatibles
+  /// constraints
   /// @param constraintMap The hasmap table of constraints which are in pairMap
   /// @param wp The index of the current step
-  /// @return a bool which is true if there is no collision or impossible to solve ones, false otherwise.
-  bool saveIncompatibleRHS(ConstraintMap_t & pairMap, ConstraintMap_t & constraintMap, size_type const wp);
+  /// @return a bool which is true if there is no collision or impossible to
+  /// solve ones, false otherwise.
+  bool saveIncompatibleRHS(ConstraintMap_t& pairMap,
+                           ConstraintMap_t& constraintMap, size_type const wp);
 
   // For a joint get his most, constrained with it, far parent
   core::JointConstPtr_t maximalJoint(size_t const wp, core::JointConstPtr_t a);

--- a/include/hpp/manipulation/path-planner/states-path-finder.hh
+++ b/include/hpp/manipulation/path-planner/states-path-finder.hh
@@ -193,13 +193,52 @@ class HPP_MANIPULATION_DLLAPI StatesPathFinder : public core::PathPlanner {
 
   /// Step 4 of the algorithm
   void preInitializeRHS(std::size_t j, Configuration_t& q);
-  bool analyseOptimizationProblem(const graph::Edges_t& transitions);
-  bool analyseOptimizationProblem2(const graph::Edges_t& transitions,
+  bool analyseOptimizationProblem(const graph::Edges_t& transitions,
                                    core::ProblemConstPtr_t _problem);
 
   /// Step 5 of the algorithm
   void initializeRHS(std::size_t j);
   bool solveOptimizationProblem();
+
+  // Data structure used to store a constraint right hand side as value and its name as key, both in form
+  // of hash numbers (so that names and rhs of two constraints can be easily merge).
+  // Exemple : ConstraintMap_t map = {{nameStringHash, rhsVectorHash}};
+  // With rhsVectorHash the hash of a vector_t of rights hand side constraints with hashRHS, and nameStringHash 
+  // the hash of a std::string - obtained for instance with std::hash.
+  typedef std::unordered_map<size_t, size_t> ConstraintMap_t; //map (name, rhs)
+  
+  /// @brief Get a configuration in accordance with the statuts matrix at a step j for the constraint i
+  /// @param i number of the constraint in the status matrix
+  /// @param j step of the potential solution (index of a waypoint)
+  /// @return a configuration Configuration_t which follows the status matrix indication at the given indices
+  Configuration_t getConfigStatus(size_type i, size_type j) const;
+
+  /// @brief Get the right hand side of a constraint w.r.t a set configuration for this constraint
+  /// @param constraint the constraint to compute the right hand side of
+  /// @param q the configuration in which the constraint is set
+  /// @return a right hand side vector_t
+  vector_t getConstraintRHS(ImplicitPtr_t constraint, Configuration_t q) const;
+
+  /// @brief Hash a vector of right hand side into a long unsigned integer
+  /// @param rhs the right hand side vector vector_t
+  /// @return a size_t integer hash
+  size_t hashRHS(vector_t rhs) const;
+
+  /// @brief Check if a solution (a list of transition) contains impossible to solve steps due to inevitable collisions
+  /// @param pairMap The ConstraintMap_tf table of pairs of incompatibles constraints
+  /// @param constraintMap The hasmap table of constraints which are in pairMap
+  /// @return a bool which is true is there is no impossible to solve steps, true otherwise
+  bool checkSolvers(ConstraintMap_t const & pairMap, ConstraintMap_t const & constraintMap) const;
+
+  /// @brief For a certain step wp during solving check for collision impossible to solve.
+  /// @param pairMap The ConstraintMap_t table of pairs of incompatibles constraints
+  /// @param constraintMap The hasmap table of constraints which are in pairMap
+  /// @param wp The index of the current step
+  /// @return a bool which is true if there is no collision or impossible to solve ones, false otherwise.
+  bool saveIncompatibleRHS(ConstraintMap_t & pairMap, ConstraintMap_t & constraintMap, size_type const wp);
+
+  // For a joint get his most, constrained with it, far parent
+  core::JointConstPtr_t maximalJoint(size_t const wp, core::JointConstPtr_t a);
 
   /// Step 6 of the algorithm
   core::Configurations_t getConfigList() const;

--- a/src/path-planner/states-path-finder.cc
+++ b/src/path-planner/states-path-finder.cc
@@ -17,8 +17,12 @@
 // received a copy of the GNU Lesser General Public License along with
 // hpp-manipulation. If not, see <http://www.gnu.org/licenses/>.
 
-#define HPP_DEBUG
 #include <algorithm>
+#include <iomanip>
+#include <ranges>
+#include <stack>
+#include <typeinfo>
+#include <unordered_map>
 #include <hpp/constraints/affine-function.hh>
 #include <hpp/constraints/explicit.hh>
 #include <hpp/constraints/locked-joint.hh>
@@ -45,15 +49,10 @@
 #include <hpp/util/debug.hh>
 #include <hpp/util/exception-factory.hh>
 #include <hpp/util/timer.hh>
-#include <iomanip>
 #include <map>
 #include <pinocchio/fwd.hpp>
 #include <pinocchio/multibody/model.hpp>
 #include <queue>
-#include <ranges>
-#include <stack>
-#include <typeinfo>
-#include <unordered_map>
 #include <vector>
 
 namespace hpp {
@@ -79,7 +78,6 @@ using core::problemTarget::TaskTarget;
 using core::problemTarget::TaskTargetPtr_t;
 
 #ifdef HPP_DEBUG
-/*
 static void displayRoadmap(const core::RoadmapPtr_t& roadmap) {
   unsigned i = 0;
   for (auto cc : roadmap->connectedComponents()) {
@@ -88,7 +86,7 @@ static void displayRoadmap(const core::RoadmapPtr_t& roadmap) {
       hppDout(info, pinocchio::displayConfig(n->configuration()));
     }
   }
-}*/
+}
 #endif
 
 StatesPathFinder::StatesPathFinder(const core::ProblemConstPtr_t& problem,
@@ -1125,9 +1123,9 @@ size_t StatesPathFinder::hashRHS(vector_t rhs) const {
   return std::hash<std::string>{}(ss.str());
 }
 
-// Check if a solution (a list of transition) contains impossible to solve steps
-// due to inevitable collisions A step is impossible to solve if it has two
-// constraints set from init or goal which have produce a collision between
+// Check if a solution (a list of transitions) contains impossible to solve steps
+// due to inevitable collisions. A step is impossible to solve if it has two
+// constraints set from init or goal which have produced a collision between
 // objects constrained by them.
 // The list of such known constraint pairs are memorized in pairMap table and
 // individually in constraintMap.
@@ -1318,6 +1316,8 @@ bool StatesPathFinder::saveIncompatibleRHS(ConstraintMap_t& pairMap,
         return std::vector<int>{-1, -1};
       };
 
+      // indices contains the two indices of the constraints that constraint pose of j1
+      // with respect to j2, if any, or { -1, -1}
       auto indices = getIndices();
 
       // Make sure indices are all defined

--- a/src/path-planner/states-path-finder.cc
+++ b/src/path-planner/states-path-finder.cc
@@ -18,11 +18,6 @@
 // hpp-manipulation. If not, see <http://www.gnu.org/licenses/>.
 
 #include <algorithm>
-#include <iomanip>
-#include <ranges>
-#include <stack>
-#include <typeinfo>
-#include <unordered_map>
 #include <hpp/constraints/affine-function.hh>
 #include <hpp/constraints/explicit.hh>
 #include <hpp/constraints/locked-joint.hh>
@@ -49,10 +44,15 @@
 #include <hpp/util/debug.hh>
 #include <hpp/util/exception-factory.hh>
 #include <hpp/util/timer.hh>
+#include <iomanip>
 #include <map>
 #include <pinocchio/fwd.hpp>
 #include <pinocchio/multibody/model.hpp>
 #include <queue>
+#include <ranges>
+#include <stack>
+#include <typeinfo>
+#include <unordered_map>
 #include <vector>
 
 namespace hpp {
@@ -1123,9 +1123,9 @@ size_t StatesPathFinder::hashRHS(vector_t rhs) const {
   return std::hash<std::string>{}(ss.str());
 }
 
-// Check if a solution (a list of transitions) contains impossible to solve steps
-// due to inevitable collisions. A step is impossible to solve if it has two
-// constraints set from init or goal which have produced a collision between
+// Check if a solution (a list of transitions) contains impossible to solve
+// steps due to inevitable collisions. A step is impossible to solve if it has
+// two constraints set from init or goal which have produced a collision between
 // objects constrained by them.
 // The list of such known constraint pairs are memorized in pairMap table and
 // individually in constraintMap.
@@ -1316,8 +1316,8 @@ bool StatesPathFinder::saveIncompatibleRHS(ConstraintMap_t& pairMap,
         return std::vector<int>{-1, -1};
       };
 
-      // indices contains the two indices of the constraints that constraint pose of j1
-      // with respect to j2, if any, or { -1, -1}
+      // indices contains the two indices of the constraints that constraint
+      // pose of j1 with respect to j2, if any, or { -1, -1}
       auto indices = getIndices();
 
       // Make sure indices are all defined


### PR DESCRIPTION
When a solver has constraints set from init or goal configuration on two objects and that objects collides, then the potential solution is impossible to solve and discarded.