### PR TITLE
[Device] Make class derive from std::enable_shared_from_this.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ ci:
   autoupdate_branch: devel
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.9.1
+  rev: v0.9.2
   hooks:
   - id: ruff
     args:
@@ -19,7 +19,7 @@ repos:
   - id: toml-sort-fix
     exclude: poetry.lock
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v19.1.6
+  rev: v19.1.7
   hooks:
   - id: clang-format
     args:

--- a/include/hpp/manipulation/device.hh
+++ b/include/hpp/manipulation/device.hh
@@ -55,7 +55,7 @@ class HPP_MANIPULATION_DLLAPI Device
   /// \param name of the new instance,
   static DevicePtr_t create(const std::string& name);
 
-  DevicePtr_t self() const { return self_.lock(); }
+  DevicePtr_t self() { return shared_from_this(); }
 
   /// Print object in a stream
   virtual std::ostream& print(std::ostream& os) const;
@@ -85,19 +85,14 @@ class HPP_MANIPULATION_DLLAPI Device
 
   void init(const DeviceWkPtr_t& self) {
     Parent_t::init(self);
-    self_ = self;
   }
 
   void initCopy(const DeviceWkPtr_t& self, const Device& other) {
     Parent_t::initCopy(self, other);
-    self_ = self;
   }
 
   /// For serialization only
   Device() {}
-
- private:
-  DeviceWkPtr_t self_;
 
   HPP_SERIALIZABLE();
 };  // class Device

--- a/include/hpp/manipulation/device.hh
+++ b/include/hpp/manipulation/device.hh
@@ -51,12 +51,7 @@ class HPP_MANIPULATION_DLLAPI Device : public pinocchio::HumanoidRobot {
 
   /// Constructor
   /// \param name of the new instance,
-  static DevicePtr_t create(const std::string& name) {
-    Device* ptr = new Device(name);
-    DevicePtr_t shPtr(ptr);
-    ptr->init(shPtr);
-    return shPtr;
-  }
+  static DevicePtr_t create(const std::string& name);
 
   DevicePtr_t self() const { return self_.lock(); }
 
@@ -84,7 +79,7 @@ class HPP_MANIPULATION_DLLAPI Device : public pinocchio::HumanoidRobot {
   /// \param name of the new instance,
   /// \param robot Robots that manipulate objects,
   /// \param objects Set of objects manipulated by the robot.
-  Device(const std::string& name) : Parent_t(name) {}
+  Device(const std::string& name);
 
   void init(const DeviceWkPtr_t& self) {
     Parent_t::init(self);

--- a/include/hpp/manipulation/device.hh
+++ b/include/hpp/manipulation/device.hh
@@ -45,7 +45,9 @@ namespace manipulation {
 ///
 /// This class also contains pinocchio::Gripper, Handle and \ref
 /// JointAndShapes_t
-class HPP_MANIPULATION_DLLAPI Device : public pinocchio::HumanoidRobot {
+class HPP_MANIPULATION_DLLAPI Device : public pinocchio::HumanoidRobot,
+  public std::enable_shared_from_this <Device>
+  {
  public:
   typedef pinocchio::HumanoidRobot Parent_t;
 

--- a/include/hpp/manipulation/device.hh
+++ b/include/hpp/manipulation/device.hh
@@ -45,9 +45,9 @@ namespace manipulation {
 ///
 /// This class also contains pinocchio::Gripper, Handle and \ref
 /// JointAndShapes_t
-class HPP_MANIPULATION_DLLAPI Device : public pinocchio::HumanoidRobot,
-  public std::enable_shared_from_this <Device>
-  {
+class HPP_MANIPULATION_DLLAPI Device
+    : public pinocchio::HumanoidRobot,
+      public std::enable_shared_from_this<Device> {
  public:
   typedef pinocchio::HumanoidRobot Parent_t;
 

--- a/include/hpp/manipulation/device.hh
+++ b/include/hpp/manipulation/device.hh
@@ -83,9 +83,7 @@ class HPP_MANIPULATION_DLLAPI Device
   /// \param objects Set of objects manipulated by the robot.
   Device(const std::string& name);
 
-  void init(const DeviceWkPtr_t& self) {
-    Parent_t::init(self);
-  }
+  void init(const DeviceWkPtr_t& self) { Parent_t::init(self); }
 
   void initCopy(const DeviceWkPtr_t& self, const Device& other) {
     Parent_t::initCopy(self, other);

--- a/src/device.cc
+++ b/src/device.cc
@@ -139,7 +139,8 @@ void Device::removeJoints(const std::vector<std::string>& jointNames,
   Parent_t::removeJoints(jointNames, referenceConfig);
 
   for (auto& pair : grippers.map)
-    pair.second = pinocchio::Gripper::create(pair.second->name(), shared_from_this());
+    pair.second =
+        pinocchio::Gripper::create(pair.second->name(), shared_from_this());
   // TODO update handles and jointAndShapes
 }
 

--- a/src/device.cc
+++ b/src/device.cc
@@ -139,7 +139,7 @@ void Device::removeJoints(const std::vector<std::string>& jointNames,
   Parent_t::removeJoints(jointNames, referenceConfig);
 
   for (auto& pair : grippers.map)
-    pair.second = pinocchio::Gripper::create(pair.second->name(), self_);
+    pair.second = pinocchio::Gripper::create(pair.second->name(), shared_from_this());
   // TODO update handles and jointAndShapes
 }
 
@@ -169,7 +169,6 @@ void Device::serialize(Archive& ar, const unsigned int version) {
                    name_, false) != this);
   ar& BOOST_SERIALIZATION_NVP(written);
   if (written) {
-    ar& BOOST_SERIALIZATION_NVP(self_);
     // TODO (easy) add serialization of core::Container ?
     // ar & BOOST_SERIALIZATION_NVP(handles);
     // ar & BOOST_SERIALIZATION_NVP(grippers);

--- a/src/device.cc
+++ b/src/device.cc
@@ -43,6 +43,17 @@ namespace hpp {
 namespace manipulation {
 using ::pinocchio::Frame;
 
+DevicePtr_t Device::create(const std::string& name) {
+  Device* ptr = new Device(name);
+  DevicePtr_t shPtr(ptr);
+  ptr->init(shPtr);
+  return shPtr;
+}
+
+Device::Device(const std::string& name) : Parent_t(name)
+{
+}
+
 pinocchio::DevicePtr_t Device::clone() const {
   Device* ptr = new Device(*this);
   DevicePtr_t shPtr(ptr);

--- a/src/device.cc
+++ b/src/device.cc
@@ -50,9 +50,7 @@ DevicePtr_t Device::create(const std::string& name) {
   return shPtr;
 }
 
-Device::Device(const std::string& name) : Parent_t(name)
-{
-}
+Device::Device(const std::string& name) : Parent_t(name) {}
 
 pinocchio::DevicePtr_t Device::clone() const {
   Device* ptr = new Device(*this);


### PR DESCRIPTION
This modification fixes a bug in the way hpp::python handles weak pointers.
See https://stackoverflow.com/questions/8233252/boostpython-and-weak-ptr-stuff-disappearing for details about the issue and the recommended fix.

