### PR TITLE
Fix and improve TransitionPlanner

### DIFF
--- a/include/hpp/manipulation/path-planner/transition-planner.hh
+++ b/include/hpp/manipulation/path-planner/transition-planner.hh
@@ -55,6 +55,11 @@ namespace pathPlanner {
 /// core::PathPlanner instance. They are respectively called the inner problem
 /// and the inner planner.
 ///
+/// In order to take into account security margins, when selecting a transition,
+/// the list of configuration validations passed to the inner problem are
+///  \li the PathValidation instance of the transition, cast into core::ConfigValidation type
+///  \li a core::JointBoundValidation instance.
+///
 /// The leaf of the transition is defined by the initial configuration passed
 /// to method \link TransitionPlanner::planPath planPath \endlink.
 /// The right hand side of the inner problem constraints is initialized with

--- a/include/hpp/manipulation/path-planner/transition-planner.hh
+++ b/include/hpp/manipulation/path-planner/transition-planner.hh
@@ -111,9 +111,9 @@ class HPP_MANIPULATION_DLLAPI TransitionPlanner : public core::PathPlanner {
   /// continuity.
   PathPtr_t directPath(ConfigurationIn_t q1, ConfigurationIn_t q2,
                        bool validate, bool& success, std::string& status);
-  /// Validate a configuration with the path validation of an edge.
+  /// Validate a configuration with the path validation of a transition.
   /// \param q configuration to validate,
-  /// \param id index of the edge in the constraint graph.
+  /// \param id index of the transition in the constraint graph.
   bool validateConfiguration(ConfigurationIn_t q, std::size_t id,
                              core::ValidationReportPtr_t& report) const;
   /// Optimize path using the selected path optimizers
@@ -128,7 +128,7 @@ class HPP_MANIPULATION_DLLAPI TransitionPlanner : public core::PathPlanner {
   PathVectorPtr_t timeParameterization(const PathVectorPtr_t& path);
 
   /// Set transition along which we wish to plan a path
-  /// \param id index of the edge in the constraint graph
+  /// \param id index of the transition in the constraint graph
   void setEdge(std::size_t id);
 
   /// Set transition along which we wish to plan a path
@@ -171,7 +171,7 @@ class HPP_MANIPULATION_DLLAPI TransitionPlanner : public core::PathPlanner {
  private:
   /// Check problem and forward maxIterations and timeout to inner problem.
   void checkProblemAndForwardParameters();
-  /// Get pointer to edge from an id
+  /// Get pointer to transition from an id
   graph::EdgePtr_t getEdgeOrThrow(std::size_t id) const;
   /// Pointer to the problem of the inner planner
   core::ProblemPtr_t innerProblem_;

--- a/include/hpp/manipulation/path-planner/transition-planner.hh
+++ b/include/hpp/manipulation/path-planner/transition-planner.hh
@@ -181,6 +181,8 @@ class HPP_MANIPULATION_DLLAPI TransitionPlanner : public core::PathPlanner {
   std::vector<PathOptimizerPtr_t> pathOptimizers_;
   /// Time parameterization instance
   core::PathOptimizerPtr_t timeParameterization_;
+  /// Whether method transition has been selected
+  bool transitionSelected_;
   /// weak pointer to itself
   TransitionPlannerWkPtr_t weakPtr_;
 };  // class TransitionPlanner

--- a/include/hpp/manipulation/path-planner/transition-planner.hh
+++ b/include/hpp/manipulation/path-planner/transition-planner.hh
@@ -57,7 +57,8 @@ namespace pathPlanner {
 ///
 /// In order to take into account security margins, when selecting a transition,
 /// the list of configuration validations passed to the inner problem are
-///  \li the PathValidation instance of the transition, cast into core::ConfigValidation type
+///  \li the PathValidation instance of the transition, cast into
+///  core::ConfigValidation type
 ///  \li a core::JointBoundValidation instance.
 ///
 /// The leaf of the transition is defined by the initial configuration passed

--- a/src/path-planner/transition-planner.cc
+++ b/src/path-planner/transition-planner.cc
@@ -99,10 +99,12 @@ core::PathVectorPtr_t TransitionPlanner::planPath(const Configuration_t qInit,
                                                   matrixIn_t qGoals,
                                                   bool resetRoadmap) {
   if (!transitionSelected_) {
-    throw std::runtime_error("hpp::manipulation::TransitionPlanner::planPath: you need to select "
-                             "the constraint graph transition first.");
+    throw std::runtime_error(
+        "hpp::manipulation::TransitionPlanner::planPath: you need to select "
+        "the constraint graph transition first.");
   }
-  // Initialize right hand side of transition constraint with the initial configuration
+  // Initialize right hand side of transition constraint with the initial
+  // configuration
   ConfigProjectorPtr_t configProjector(
       innerProblem_->constraints()->configProjector());
   if (configProjector) {
@@ -138,8 +140,9 @@ core::PathPtr_t TransitionPlanner::directPath(ConfigurationIn_t q1,
                                               bool validate, bool& success,
                                               std::string& status) {
   if (!transitionSelected_) {
-    throw std::runtime_error("hpp::manipulation::TransitionPlanner::planPath: you need to select "
-                             "the constraint graph transition first.");
+    throw std::runtime_error(
+        "hpp::manipulation::TransitionPlanner::planPath: you need to select "
+        "the constraint graph transition first.");
   }
   core::PathPtr_t res(innerProblem_->steeringMethod()->steer(q1, q2));
   if (!res) {
@@ -201,37 +204,42 @@ void TransitionPlanner::setEdge(std::size_t id) {
   setEdge(edge);
 }
 
-// This class transforms a PathValidation instace into a ConfigValidation instance
+// This class transforms a PathValidation instace into a ConfigValidation
+// instance
 class FromPathValidation : public core::ConfigValidation {
-public:
+ public:
   typedef shared_ptr<FromPathValidation> Ptr_t;
   typedef core::ValidationReportPtr_t ValidationReportPtr_t;
   static Ptr_t create(const PathValidationPtr_t& pathValidation) {
-    return Ptr_t (new FromPathValidation(pathValidation));
+    return Ptr_t(new FromPathValidation(pathValidation));
   }
-  bool validate(const Configuration_t& config, ValidationReportPtr_t& validationReport) {
-    return pathValidation_->validate (config, validationReport);
+  bool validate(const Configuration_t& config,
+                ValidationReportPtr_t& validationReport) {
+    return pathValidation_->validate(config, validationReport);
   }
-protected:
-  FromPathValidation(const PathValidationPtr_t& pathValidation) :
-    pathValidation_ (pathValidation) {
-  }
-private:
+
+ protected:
+  FromPathValidation(const PathValidationPtr_t& pathValidation)
+      : pathValidation_(pathValidation) {}
+
+ private:
   PathValidationPtr_t pathValidation_;
-}; // class FromPathValidation
+};  // class FromPathValidation
 
 void TransitionPlanner::setEdge(const graph::EdgePtr_t& edge) {
   innerProblem_->constraints(edge->pathConstraint());
   innerProblem_->pathValidation(edge->pathValidation());
   innerProblem_->steeringMethod(edge->steeringMethod());
-  // Use path validation of the transition to validate initial and goal configurations.
-  // Security margins handled by PathValidation instances of the edges are not
-  // taken into account in the ConfigValidations. As a consequence, some
-  // configurations valid for the transition are in collision for the ConfigValidation.
+  // Use path validation of the transition to validate initial and goal
+  // configurations. Security margins handled by PathValidation instances of the
+  // edges are not taken into account in the ConfigValidations. As a
+  // consequence, some configurations valid for the transition are in collision
+  // for the ConfigValidation.
   innerProblem_->clearConfigValidations();
   innerProblem_->configValidations()->add(
-    hpp::core::JointBoundValidation::create(problem()->robot()));
-  innerProblem_->configValidations()->add(FromPathValidation::create(edge->pathValidation()));
+      hpp::core::JointBoundValidation::create(problem()->robot()));
+  innerProblem_->configValidations()->add(
+      FromPathValidation::create(edge->pathValidation()));
   transitionSelected_ = true;
 }
 
@@ -264,8 +272,8 @@ void TransitionPlanner::setParameter(const std::string& key,
 }
 
 TransitionPlanner::TransitionPlanner(const core::ProblemConstPtr_t& problem,
-                                     const core::RoadmapPtr_t& roadmap) :
-  PathPlanner(problem, roadmap), transitionSelected_ (false) {
+                                     const core::RoadmapPtr_t& roadmap)
+    : PathPlanner(problem, roadmap), transitionSelected_(false) {
   ProblemConstPtr_t p(HPP_DYNAMIC_PTR_CAST(const Problem, problem));
   if (!p)
     throw std::invalid_argument(

--- a/src/path-planner/transition-planner.cc
+++ b/src/path-planner/transition-planner.cc
@@ -98,6 +98,10 @@ void TransitionPlanner::oneStep() { innerPlanner_->oneStep(); }
 core::PathVectorPtr_t TransitionPlanner::planPath(const Configuration_t qInit,
                                                   matrixIn_t qGoals,
                                                   bool resetRoadmap) {
+  if (!transitionSelected_) {
+    throw std::runtime_error("hpp::manipulation::TransitionPlanner::planPath: you need to select "
+                             "the constraint graph transition first.");
+  }
   ConfigProjectorPtr_t configProjector(
       innerProblem_->constraints()->configProjector());
   if (configProjector) {
@@ -131,6 +135,10 @@ core::PathPtr_t TransitionPlanner::directPath(ConfigurationIn_t q1,
                                               ConfigurationIn_t q2,
                                               bool validate, bool& success,
                                               std::string& status) {
+  if (!transitionSelected_) {
+    throw std::runtime_error("hpp::manipulation::TransitionPlanner::planPath: you need to select "
+                             "the constraint graph transition first.");
+  }
   core::PathPtr_t res(innerProblem_->steeringMethod()->steer(q1, q2));
   if (!res) {
     success = false;
@@ -195,6 +203,7 @@ void TransitionPlanner::setEdge(const graph::EdgePtr_t& edge) {
   innerProblem_->constraints(edge->pathConstraint());
   innerProblem_->pathValidation(edge->pathValidation());
   innerProblem_->steeringMethod(edge->steeringMethod());
+  transitionSelected_ = true;
 }
 
 void TransitionPlanner::setReedsAndSheppSteeringMethod(double turningRadius) {
@@ -226,8 +235,8 @@ void TransitionPlanner::setParameter(const std::string& key,
 }
 
 TransitionPlanner::TransitionPlanner(const core::ProblemConstPtr_t& problem,
-                                     const core::RoadmapPtr_t& roadmap)
-    : PathPlanner(problem, roadmap) {
+                                     const core::RoadmapPtr_t& roadmap) :
+  PathPlanner(problem, roadmap), transitionSelected_ (false) {
   ProblemConstPtr_t p(HPP_DYNAMIC_PTR_CAST(const Problem, problem));
   if (!p)
     throw std::invalid_argument(

--- a/src/path-planner/transition-planner.cc
+++ b/src/path-planner/transition-planner.cc
@@ -102,11 +102,13 @@ core::PathVectorPtr_t TransitionPlanner::planPath(const Configuration_t qInit,
     throw std::runtime_error("hpp::manipulation::TransitionPlanner::planPath: you need to select "
                              "the constraint graph transition first.");
   }
+  // Initialize right hand side of transition constraint with the initial configuration
   ConfigProjectorPtr_t configProjector(
       innerProblem_->constraints()->configProjector());
   if (configProjector) {
     configProjector->rightHandSideFromConfig(qInit);
   }
+  // Set initial and goal configurations in inner problem
   Configuration_t q(qInit);
   innerProblem_->initConfig(q);
   innerProblem_->resetGoalConfigs();
@@ -199,10 +201,37 @@ void TransitionPlanner::setEdge(std::size_t id) {
   setEdge(edge);
 }
 
+// This class transforms a PathValidation instace into a ConfigValidation instance
+class FromPathValidation : public core::ConfigValidation {
+public:
+  typedef shared_ptr<FromPathValidation> Ptr_t;
+  typedef core::ValidationReportPtr_t ValidationReportPtr_t;
+  static Ptr_t create(const PathValidationPtr_t& pathValidation) {
+    return Ptr_t (new FromPathValidation(pathValidation));
+  }
+  bool validate(const Configuration_t& config, ValidationReportPtr_t& validationReport) {
+    return pathValidation_->validate (config, validationReport);
+  }
+protected:
+  FromPathValidation(const PathValidationPtr_t& pathValidation) :
+    pathValidation_ (pathValidation) {
+  }
+private:
+  PathValidationPtr_t pathValidation_;
+}; // class FromPathValidation
+
 void TransitionPlanner::setEdge(const graph::EdgePtr_t& edge) {
   innerProblem_->constraints(edge->pathConstraint());
   innerProblem_->pathValidation(edge->pathValidation());
   innerProblem_->steeringMethod(edge->steeringMethod());
+  // Use path validation of the transition to validate initial and goal configurations.
+  // Security margins handled by PathValidation instances of the edges are not
+  // taken into account in the ConfigValidations. As a consequence, some
+  // configurations valid for the transition are in collision for the ConfigValidation.
+  innerProblem_->clearConfigValidations();
+  innerProblem_->configValidations()->add(
+    hpp::core::JointBoundValidation::create(problem()->robot()));
+  innerProblem_->configValidations()->add(FromPathValidation::create(edge->pathValidation()));
   transitionSelected_ = true;
 }
 
@@ -249,12 +278,6 @@ TransitionPlanner::TransitionPlanner(const core::ProblemConstPtr_t& problem,
   for (auto k : keys) {
     innerProblem_->setParameter(k, p->parameters.get(k));
   }
-  // Initialize config validations
-  innerProblem_->clearConfigValidations();
-  innerProblem_->configValidations()->add(
-      hpp::core::CollisionValidation::create(p->robot()));
-  innerProblem_->configValidations()->add(
-      hpp::core::JointBoundValidation::create(p->robot()));
   // Add obstacles to inner problem
   innerProblem_->collisionObstacles(p->collisionObstacles());
   // Create default path planner


### PR DESCRIPTION
  - Replace edge by transition in documentation.
  - Check that a transition has been selected before planning.
  - Fix problem validation when using security margins.