### PR TITLE
Refactor EndEffectorTrajectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,7 @@ set(${PROJECT_NAME}_HEADERS
     include/hpp/manipulation/path-planner/transition-planner.hh
     include/hpp/manipulation/problem-target/state.hh
     include/hpp/manipulation/serialization.hh
+    include/hpp/manipulation/steering-method/cartesian.hh
     include/hpp/manipulation/steering-method/cross-state-optimization.hh
     include/hpp/manipulation/steering-method/fwd.hh
     include/hpp/manipulation/steering-method/graph.hh
@@ -149,6 +150,7 @@ set(${PROJECT_NAME}_SOURCES
     src/path-planner/transition-planner.cc
     src/problem-target/state.cc
     src/serialization.cc
+    src/steering-method/cartesian.cc
     src/steering-method/end-effector-trajectory.cc
     src/steering-method/cross-state-optimization.cc
     src/steering-method/graph.cc)

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1769996383,
-        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "lastModified": 1772408722,
+        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
         "type": "github"
       },
       "original": {
@@ -60,11 +60,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1772816781,
-        "narHash": "sha256-Ac0KEl+8ygy+BnDgczNHgTumw8HpCasp/zJU5Yx3kQs=",
+        "lastModified": 1773524302,
+        "narHash": "sha256-0phiMh2h3tZoe3rJGWWKMMJhuLMMHa65hRtgkzbXBJQ=",
         "owner": "gepetto",
         "repo": "gazebros2nix",
-        "rev": "ea8aff2fca6d45fa85fe5e90ef3c71fe0fcc0d12",
+        "rev": "0eb9151c41ec370e29d4d4ae1640aa4c6c4aa7a7",
         "type": "github"
       },
       "original": {
@@ -81,6 +81,7 @@
           "flake-parts"
         ],
         "gazebros2nix": "gazebros2nix",
+        "home-manager": "home-manager",
         "nix-ros-overlay": [
           "gepetto",
           "gazebros2nix",
@@ -107,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772840692,
-        "narHash": "sha256-DXSHWpxQ+P0dVgXk05MxdHJ3Vf6l3r8nzTqelhi74Zo=",
+        "lastModified": 1773834979,
+        "narHash": "sha256-pxEUfvPZG3lMMiorJxKPt0kjjNE2gQDA3w/cRHvSUX4=",
         "owner": "gepetto",
         "repo": "nix",
-        "rev": "623983d5faef9aeac4b9ef4be107a71c3969d53c",
+        "rev": "57036f98001a3b66384cd68ace974d237e3fa78b",
         "type": "github"
       },
       "original": {
@@ -122,16 +123,38 @@
     },
     "gepetto-lib": {
       "locked": {
-        "lastModified": 1770945346,
-        "narHash": "sha256-L88f+oJbpIkMm9Ln1GP9SFyGztMvnOowbdshQHBeGGs=",
+        "lastModified": 1772454823,
+        "narHash": "sha256-jROeQxiRkzpHHAWDAxHJVfW/liA+t6JKDyPMJFqUE9E=",
         "owner": "Gepetto",
         "repo": "nix-lib",
-        "rev": "82ef58cdf50514f6b1fde96b9d5b38fd8d3e83f5",
+        "rev": "4500b5aa6af20c60011926ad6f42238375779c90",
         "type": "github"
       },
       "original": {
         "owner": "Gepetto",
         "repo": "nix-lib",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "gepetto",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773681845,
+        "narHash": "sha256-o8hrZrigP0JYcwnglCp8Zi8jQafWsxbDtRRPzuVwFxY=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "0759e0e137305bc9d0c52c204c6d8dffe6f601a6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "release-25.11",
+        "repo": "home-manager",
         "type": "github"
       }
     },
@@ -141,11 +164,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1771885942,
-        "narHash": "sha256-TlBFvE4YHNlbhKVkayP/FWBNAAv+yG9APA8vMR+5NBw=",
+        "lastModified": 1773393994,
+        "narHash": "sha256-zm24obq1c4ielRR8KlUQ2M5XnNfUIcQjN++9s6CFvxc=",
         "owner": "lopsided98",
         "repo": "nix-ros-overlay",
-        "rev": "f891b118c8f4ddb2b6f38d6ce1bfe2f8079552ba",
+        "rev": "a522c5a050a6d50471a29bbf6a060e2df16abf44",
         "type": "github"
       },
       "original": {
@@ -194,11 +217,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1769909678,
-        "narHash": "sha256-cBEymOf4/o3FD5AZnzC3J9hLbiZ+QDT/KDuyHXVJOpM=",
+        "lastModified": 1772328832,
+        "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "72716169fe93074c333e8d0173151350670b824c",
+        "rev": "c185c7a5e5dd8f9add5b2f8ebeff00888b070742",
         "type": "github"
       },
       "original": {
@@ -226,11 +249,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771423342,
-        "narHash": "sha256-7uXPiWB0YQ4HNaAqRvVndYL34FEp1ZTwVQHgZmyMtC8=",
+        "lastModified": 1772555609,
+        "narHash": "sha256-3BA3HnUvJSbHJAlJj6XSy0Jmu7RyP2gyB/0fL7XuEDo=",
         "owner": "pyproject-nix",
         "repo": "build-system-pkgs",
-        "rev": "04e9c186e01f0830dad3739088070e4c551191a4",
+        "rev": "c37f66a953535c394244888598947679af231863",
         "type": "github"
       },
       "original": {
@@ -248,11 +271,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771518446,
-        "narHash": "sha256-nFJSfD89vWTu92KyuJWDoTQJuoDuddkJV3TlOl1cOic=",
+        "lastModified": 1773190977,
+        "narHash": "sha256-fkJvOxz80cJViPz6GVaayC8BVCs5fclJ8qHDaNUpoEA=",
         "owner": "pyproject-nix",
         "repo": "pyproject.nix",
-        "rev": "eb204c6b3335698dec6c7fc1da0ebc3c6df05937",
+        "rev": "10ebca8a137bf26b7fbd3e94b339bf68cee18693",
         "type": "github"
       },
       "original": {
@@ -369,11 +392,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770228511,
-        "narHash": "sha256-wQ6NJSuFqAEmIg2VMnLdCnUc0b7vslUohqqGGD+Fyxk=",
+        "lastModified": 1773297127,
+        "narHash": "sha256-6E/yhXP7Oy/NbXtf1ktzmU8SdVqJQ09HC/48ebEGBpk=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "337a4fe074be1042a35086f15481d763b8ddc0e7",
+        "rev": "71b125cd05fbfd78cab3e070b73544abe24c5016",
         "type": "github"
       },
       "original": {
@@ -396,11 +419,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772187362,
-        "narHash": "sha256-gCojeIlQ/rfWMe3adif3akyHsT95wiMkLURpxTeqmPc=",
+        "lastModified": 1773359304,
+        "narHash": "sha256-knv2C6tIk5ysix+9TxWIenPvpB20kFjQ1CH6SJMBNsU=",
         "owner": "pyproject-nix",
         "repo": "uv2nix",
-        "rev": "abe65de114300de41614002fe9dce2152ac2ac23",
+        "rev": "27b135ea72ab1637fc5845a61c101ea66d6636d6",
         "type": "github"
       },
       "original": {

--- a/include/hpp/manipulation/graph/graph-component.hh
+++ b/include/hpp/manipulation/graph/graph-component.hh
@@ -33,7 +33,6 @@
 #include <string>
 
 #include "hpp/manipulation/config.hh"
-#include "hpp/manipulation/deprecated.hh"
 #include "hpp/manipulation/fwd.hh"
 #include "hpp/manipulation/graph/dot.hh"
 #include "hpp/manipulation/graph/fwd.hh"

--- a/include/hpp/manipulation/path-planner/end-effector-trajectory.hh
+++ b/include/hpp/manipulation/path-planner/end-effector-trajectory.hh
@@ -30,9 +30,12 @@
 #define HPP_MANIPULATION_PATH_PLANNER_END_EFFECTOR_TRAJECTORY_HH
 
 #include <hpp/core/path-planner.hh>
+
 #include <hpp/manipulation/config.hh>
+#include <hpp/manipulation/deprecated.hh>
 #include <hpp/manipulation/fwd.hh>
 #include <hpp/pinocchio/frame.hh>
+
 #include <pinocchio/spatial/se3.hpp>
 
 namespace hpp {
@@ -92,18 +95,20 @@ typedef shared_ptr<EndEffectorTrajectory> EndEffectorTrajectoryPtr_t;
 /// Note that continuity is not tested but enforced by projecting the
 /// configuration of the previous sample to compute the configuration at
 /// a given sample.
-class HPP_MANIPULATION_DLLAPI EndEffectorTrajectory : public core::PathPlanner {
+/// \deprecated This class has been reimplemented and simplified as steeringMethod::Cartesian.
+class HPP_MANIPULATION_DLLAPI EndEffectorTrajectory :
+    public core::PathPlanner {
  public:
   /// Return shared pointer to new instance
   /// \param problem the path planning problem
   static EndEffectorTrajectoryPtr_t create(
-      const core::ProblemConstPtr_t& problem);
+      const core::ProblemConstPtr_t& problem) HPP_MANIPULATION_DEPRECATED;
   /// Return shared pointer to new instance
   /// \param problem the path planning problem
   /// \param roadmap previously built roadmap
   static EndEffectorTrajectoryPtr_t createWithRoadmap(
       const core::ProblemConstPtr_t& problem,
-      const core::RoadmapPtr_t& roadmap);
+      const core::RoadmapPtr_t& roadmap) HPP_MANIPULATION_DEPRECATED;
 
   /// Initialize the problem resolution
   ///  \li call parent implementation

--- a/include/hpp/manipulation/path-planner/end-effector-trajectory.hh
+++ b/include/hpp/manipulation/path-planner/end-effector-trajectory.hh
@@ -30,12 +30,10 @@
 #define HPP_MANIPULATION_PATH_PLANNER_END_EFFECTOR_TRAJECTORY_HH
 
 #include <hpp/core/path-planner.hh>
-
 #include <hpp/manipulation/config.hh>
 #include <hpp/manipulation/deprecated.hh>
 #include <hpp/manipulation/fwd.hh>
 #include <hpp/pinocchio/frame.hh>
-
 #include <pinocchio/spatial/se3.hpp>
 
 namespace hpp {
@@ -95,9 +93,9 @@ typedef shared_ptr<EndEffectorTrajectory> EndEffectorTrajectoryPtr_t;
 /// Note that continuity is not tested but enforced by projecting the
 /// configuration of the previous sample to compute the configuration at
 /// a given sample.
-/// \deprecated This class has been reimplemented and simplified as steeringMethod::Cartesian.
-class HPP_MANIPULATION_DLLAPI EndEffectorTrajectory :
-    public core::PathPlanner {
+/// \deprecated This class has been reimplemented and simplified as
+/// steeringMethod::Cartesian.
+class HPP_MANIPULATION_DLLAPI EndEffectorTrajectory : public core::PathPlanner {
  public:
   /// Return shared pointer to new instance
   /// \param problem the path planning problem

--- a/include/hpp/manipulation/problem-solver.hh
+++ b/include/hpp/manipulation/problem-solver.hh
@@ -35,7 +35,6 @@
 #include <map>
 
 #include "hpp/manipulation/constraint-set.hh"
-#include "hpp/manipulation/deprecated.hh"
 #include "hpp/manipulation/device.hh"
 #include "hpp/manipulation/fwd.hh"
 #include "hpp/manipulation/graph/fwd.hh"

--- a/include/hpp/manipulation/steering-method/cartesian.hh
+++ b/include/hpp/manipulation/steering-method/cartesian.hh
@@ -40,9 +40,10 @@ typedef shared_ptr<Cartesian> CartesianPtr_t;
 
 /// Build a robot trajectory from an end-effector trajectory
 ///
-/// This class does not derive from \link hpp::core::SteeringMethod SteeringMethod \endlink since it
-/// does not link two configurations by a path. Instead, it only takes an initial configuration
-/// and a trajectory of an end-effector.
+/// This class does not derive from \link hpp::core::SteeringMethod
+/// SteeringMethod \endlink since it does not link two configurations by a path.
+/// Instead, it only takes an initial configuration and a trajectory of an
+/// end-effector.
 ///
 /// To use this class, the user needs to provide
 ///  \li a constraint with value in \f$SE(3)\f$. An easy way to create such a
@@ -55,19 +56,18 @@ typedef shared_ptr<Cartesian> CartesianPtr_t;
 /// Cartesian::makePiecewiseLinearTrajectory
 /// makePiecewiseLinearTrajectory \endlink method may be useful.
 ///
-/// Once the steering method has been initialized, it can be called with and initial
-/// configuration \c q_init. The interval of definition \f$[0,T]\f$
-/// of the output path is the same as the one of the path provided as the right
+/// Once the steering method has been initialized, it can be called with and
+/// initial configuration \c q_init. The interval of definition \f$[0,T]\f$ of
+/// the output path is the same as the one of the path provided as the right
 /// hand side of the constraint.
 /// Note that \c q_init should satisfy the constraint at times 0.
 class Cartesian {
-
  public:
   typedef constraints::ImplicitPtr_t ImplicitPtr_t;
   typedef core::ConfigurationIn_t ConfigurationIn_t;
   typedef core::interval_t interval_t;
   typedef core::PathPtr_t PathPtr_t;
-  
+
   static CartesianPtr_t create(const core::ProblemConstPtr_t& problem);
 
   /** Build a path in SE(3).
@@ -114,9 +114,7 @@ class Cartesian {
   /// Set the trajectory constraint
   void trajectoryConstraint(const ImplicitPtr_t& ic);
   /// Get the trajectory constraint
-  const ImplicitPtr_t& trajectoryConstraint() {
-    return trajConstraint_;
-  }
+  const ImplicitPtr_t& trajectoryConstraint() { return trajConstraint_; }
   /// Set the right hand side of the trajectory constraint from a path
   /// \param rhs function from an interval to SE(3).
   /// \param se3Output set to True if the output of path must be
@@ -143,26 +141,27 @@ class Cartesian {
     nDiscreteSteps_ = n;
   }
 
-
   /// \brief Plan a path starting from an initial configuration
   ///
   /// \param q_init initial configuration
   ///
-  /// \retval result the resulting path in case of success, a valid portion of path satisfying
-  ///         the trajectory constraint along a sub-interval starting at 0 otherwise.
+  /// \retval result the resulting path in case of success, a valid portion of
+  /// path satisfying
+  ///         the trajectory constraint along a sub-interval starting at 0
+  ///         otherwise.
   /// \return true if the path is successfully computed, false otherwise
   ///
-  /// The interval of definition is discretized into a number of sub-intervals defined by
-  /// method \link Cartesian::nDiscreteSteps
-  /// nDiscreteSteps\endlink. For each discretized value, a configuration is computed by
-  /// projecting
-  /// the previous one (or the initial configuration for the first discretized value)
-  /// onto the time-varying constraint.
+  /// The interval of definition is discretized into a number of sub-intervals
+  /// defined by method \link Cartesian::nDiscreteSteps nDiscreteSteps\endlink.
+  /// For each discretized value, a configuration is computed by projecting the
+  /// previous one (or the initial configuration for the first discretized
+  /// value) onto the time-varying constraint.
   ///
   /// In case of failure, the interpolated path until the last successful
   /// projection is returned.
   ///
-  /// \note No path validation is performed. Collision checking should be performed on the output
+  /// \note No path validation is performed. Collision checking should be
+  /// performed on the output
   ///       of this method.
   bool planPath(ConfigurationIn_t q_init, PathPtr_t& result);
 
@@ -171,6 +170,7 @@ class Cartesian {
   Cartesian(const core::ProblemConstPtr_t& problem);
   PathPtr_t projectedPath(vectorIn_t times, matrixIn_t configs) const;
   void checkProblem(const std::string& method);
+
  private:
   /// Robot
   pinocchio::DevicePtr_t robot_;
@@ -180,14 +180,14 @@ class Cartesian {
   ImplicitPtr_t trajConstraint_;
   DifferentiableFunctionPtr_t rhs_;
   interval_t timeRange_;
-  /// Number of steps along the definition interval to project the configurations
+  /// Number of steps along the definition interval to project the
+  /// configurations
   size_type nDiscreteSteps_;
 
-}; // class Cartesian
+};  // class Cartesian
 
 /// \addtogroup steering_method
 /// \{
-
 
 /// \}
 
@@ -195,4 +195,4 @@ class Cartesian {
 }  // namespace manipulation
 }  // namespace hpp
 
-#endif // HPP_MANIPULATION_STEERING_METHOD_CARTESIAN_HH
+#endif  // HPP_MANIPULATION_STEERING_METHOD_CARTESIAN_HH

--- a/include/hpp/manipulation/steering-method/cartesian.hh
+++ b/include/hpp/manipulation/steering-method/cartesian.hh
@@ -1,0 +1,198 @@
+// Copyright (c) 2026, LAAS-CNRS
+// Authors: Florent Lamiraux
+//
+
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+
+#ifndef HPP_MANIPULATION_STEERING_METHOD_CARTESIAN_HH
+#define HPP_MANIPULATION_STEERING_METHOD_CARTESIAN_HH
+
+#include <hpp/manipulation/fwd.hh>
+
+namespace hpp {
+namespace manipulation {
+namespace steeringMethod {
+
+HPP_PREDEF_CLASS(Cartesian);
+typedef shared_ptr<Cartesian> CartesianPtr_t;
+
+/// Build a robot trajectory from an end-effector trajectory
+///
+/// This class does not derive from \link hpp::core::SteeringMethod SteeringMethod \endlink since it
+/// does not link two configurations by a path. Instead, it only takes an initial configuration
+/// and a trajectory of an end-effector.
+///
+/// To use this class, the user needs to provide
+///  \li a constraint with value in \f$SE(3)\f$. An easy way to create such a
+///  constraint is to use method hpp::manipulation::Handle::createGrasp. The
+///  constraint is passed to this class using method \link
+/// Cartesian::trajectoryConstraint trajectoryConstraint \endlink.
+///  \li the time-varying right hand side of this constraint along the path
+///  the user wants to create in the form of a hpp::core::Path instance
+///  with values in \f$SE(3)\f$. For that, \link
+/// Cartesian::makePiecewiseLinearTrajectory
+/// makePiecewiseLinearTrajectory \endlink method may be useful.
+///
+/// Once the steering method has been initialized, it can be called with and initial
+/// configuration \c q_init. The interval of definition \f$[0,T]\f$
+/// of the output path is the same as the one of the path provided as the right
+/// hand side of the constraint.
+/// Note that \c q_init should satisfy the constraint at times 0.
+class Cartesian {
+
+ public:
+  typedef constraints::ImplicitPtr_t ImplicitPtr_t;
+  typedef core::ConfigurationIn_t ConfigurationIn_t;
+  typedef core::interval_t interval_t;
+  typedef core::PathPtr_t PathPtr_t;
+  
+  static CartesianPtr_t create(const core::ProblemConstPtr_t& problem);
+
+  /** Build a path in SE(3).
+      \param points a Nx7 matrix whose rows corresponds to poses.
+      \param weights a 6D vector, weights to be applied when computing
+             the distance between two SE3 points.
+
+      The trajectory \f$T\f$ is defined as follows. Let \f$N\f$ be the number of
+      lines of matrix \c points, \f$p_i\f$ be the i-th line of \c points and
+      let \f$W\f$ be the
+      diagonal matrix with the coefficients of \c weights:
+      \f[
+      W = \left(\begin{array}{cccccc}
+      w_1 & 0 & 0 & 0 & 0 & 0\\
+      0 & w_2 & 0 & 0 & 0 & 0\\
+      0 & 0 & w_3 & 0 & 0 & 0\\
+      0 & 0 & 0 & w_4 & 0 & 0\\
+      0 & 0 & 0 & 0 & w_5 & 0\\
+      0 & 0 & 0 & 0 & 0 & w_6\\
+      \end{array}\right)
+      \f]
+
+      \f{eqnarray*}{
+        f(t) = \mathbf{p}_i \oplus \frac{t-t_i}{t_{i+1}-t_i}
+     (\mathbf{p}_{i+1}-\mathbf{p}_i) && \mbox{ for } t \in [t_i,t_{i+1}] \f}
+
+      where \f$t_0 = 0\f$ and
+      \f{eqnarray*}{
+       t_{i+1}-t_i = \|W(\mathbf{p}_{i+1}-\mathbf{p}_i)\| && \mbox{for } i
+       \mbox{ such that } 1 \leq i \leq N-1
+       \f} */
+  static PathPtr_t makePiecewiseLinearTrajectory(matrixIn_t points,
+                                                 vectorIn_t weights);
+
+  /// Set maximal number of iterations of numerical solver
+  void maxIterations(size_type iterations);
+  /// Get maximal number of iterations of numerical solver
+  size_type maxIterations() const;
+
+  /// Set error threshold of numerical solver
+  void errorThreshold(const value_type& threshold);
+  /// Get error threshold of numerical solver
+  value_type errorThreshold() const;
+  /// Set the trajectory constraint
+  void trajectoryConstraint(const ImplicitPtr_t& ic);
+  /// Get the trajectory constraint
+  const ImplicitPtr_t& trajectoryConstraint() {
+    return trajConstraint_;
+  }
+  /// Set the right hand side of the trajectory constraint from a path
+  /// \param rhs function from an interval to SE(3).
+  /// \param se3Output set to True if the output of path must be
+  ///                  understood as SE3.
+  void rightHandSide(const PathPtr_t& rhs, bool se3Output);
+
+  /// Set the right hand side of the function from another function.
+  /// \param rhs a function whose input space is of dimension 1.
+  /// \param timeRange the input range of eeTraj.
+  void rightHandSide(const DifferentiableFunctionPtr_t& rhs,
+                     const interval_t& timeRange);
+
+  /// Get time-varying right hand side of trajectory constraint
+  const DifferentiableFunctionPtr_t& rightHandSide() const { return rhs_; }
+
+  /// Get interval of definition of right hand side of trajectory constraint
+  const interval_t& timeRange() const { return timeRange_; }
+
+  /// Number of steps to generate goal config (successive projections).
+  size_type nDiscreteSteps() const { return nDiscreteSteps_; }
+
+  void nDiscreteSteps(size_type n) {
+    assert(n > 0);
+    nDiscreteSteps_ = n;
+  }
+
+
+  /// \brief Plan a path starting from an initial configuration
+  ///
+  /// \param q_init initial configuration
+  ///
+  /// \retval result the resulting path in case of success, a valid portion of path satisfying
+  ///         the trajectory constraint along a sub-interval starting at 0 otherwise.
+  /// \return true if the path is successfully computed, false otherwise
+  ///
+  /// The interval of definition is discretized into a number of sub-intervals defined by
+  /// method \link Cartesian::nDiscreteSteps
+  /// nDiscreteSteps\endlink. For each discretized value, a configuration is computed by
+  /// projecting
+  /// the previous one (or the initial configuration for the first discretized value)
+  /// onto the time-varying constraint.
+  ///
+  /// In case of failure, the interpolated path until the last successful
+  /// projection is returned.
+  ///
+  /// \note No path validation is performed. Collision checking should be performed on the output
+  ///       of this method.
+  bool planPath(ConfigurationIn_t q_init, PathPtr_t& result);
+
+ protected:
+  /// Store the constraints of the problem
+  Cartesian(const core::ProblemConstPtr_t& problem);
+  PathPtr_t projectedPath(vectorIn_t times, matrixIn_t configs) const;
+  void checkProblem(const std::string& method);
+ private:
+  /// Robot
+  pinocchio::DevicePtr_t robot_;
+  /// Constraints the system is subjected to, provided by the problem
+  core::ConstraintSetPtr_t constraints_;
+  /// Constraint that defined the motion of the end-effector
+  ImplicitPtr_t trajConstraint_;
+  DifferentiableFunctionPtr_t rhs_;
+  interval_t timeRange_;
+  /// Number of steps along the definition interval to project the configurations
+  size_type nDiscreteSteps_;
+
+}; // class Cartesian
+
+/// \addtogroup steering_method
+/// \{
+
+
+/// \}
+
+}  // namespace steeringMethod
+}  // namespace manipulation
+}  // namespace hpp
+
+#endif // HPP_MANIPULATION_STEERING_METHOD_CARTESIAN_HH

--- a/include/hpp/manipulation/steering-method/end-effector-trajectory.hh
+++ b/include/hpp/manipulation/steering-method/end-effector-trajectory.hh
@@ -70,15 +70,15 @@ using core::PathPtr_t;
 /// \f$T\f$ respectively. The output path is a \link hpp::core::StraightPath
 /// linear interpolation \endlink between \c q1 and \c q2 projected on the
 /// steering method constraints.
-/// \deprecated This class was used by the planner class with the same name that has been
-/// deprecated.
-class HPP_MANIPULATION_DLLAPI EndEffectorTrajectory :
-    public core::SteeringMethod {
+/// \deprecated This class was used by the planner class with the same name that
+/// has been deprecated.
+class HPP_MANIPULATION_DLLAPI EndEffectorTrajectory
+    : public core::SteeringMethod {
  public:
   typedef core::interval_t interval_t;
 
   static EndEffectorTrajectoryPtr_t create(
-      const core::ProblemConstPtr_t& problem)  HPP_MANIPULATION_DEPRECATED {
+      const core::ProblemConstPtr_t& problem) HPP_MANIPULATION_DEPRECATED {
     EndEffectorTrajectoryPtr_t ptr(new EndEffectorTrajectory(problem));
     ptr->init(ptr);
     return ptr;

--- a/include/hpp/manipulation/steering-method/end-effector-trajectory.hh
+++ b/include/hpp/manipulation/steering-method/end-effector-trajectory.hh
@@ -31,6 +31,7 @@
 
 #include <hpp/core/steering-method.hh>
 #include <hpp/manipulation/config.hh>
+#include <hpp/manipulation/deprecated.hh>
 #include <hpp/manipulation/fwd.hh>
 
 namespace hpp {
@@ -69,13 +70,15 @@ using core::PathPtr_t;
 /// \f$T\f$ respectively. The output path is a \link hpp::core::StraightPath
 /// linear interpolation \endlink between \c q1 and \c q2 projected on the
 /// steering method constraints.
-class HPP_MANIPULATION_DLLAPI EndEffectorTrajectory
-    : public core::SteeringMethod {
+/// \deprecated This class was used by the planner class with the same name that has been
+/// deprecated.
+class HPP_MANIPULATION_DLLAPI EndEffectorTrajectory :
+    public core::SteeringMethod {
  public:
   typedef core::interval_t interval_t;
 
   static EndEffectorTrajectoryPtr_t create(
-      const core::ProblemConstPtr_t& problem) {
+      const core::ProblemConstPtr_t& problem)  HPP_MANIPULATION_DEPRECATED {
     EndEffectorTrajectoryPtr_t ptr(new EndEffectorTrajectory(problem));
     ptr->init(ptr);
     return ptr;

--- a/src/steering-method/cartesian.cc
+++ b/src/steering-method/cartesian.cc
@@ -1,0 +1,287 @@
+// Copyright (c) 2026, LAAS-CNRS
+// Authors: Florent Lamiraux
+//
+
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+
+#include <stdexcept>
+
+#include <hpp/constraints/differentiable-function.hh>
+#include <hpp/constraints/implicit.hh>
+
+#include <hpp/core/config-projector.hh>
+#include <hpp/core/constraint-set.hh>
+#include <hpp/core/interpolated-path.hh>
+#include <hpp/core/path-vector.hh>
+#include <hpp/core/problem.hh>
+#include <hpp/core/straight-path.hh>
+
+#include <hpp/manipulation/steering-method/cartesian.hh>
+
+#include <hpp/pinocchio/configuration.hh>
+#include <hpp/pinocchio/liegroup-space.hh>
+
+#include <hpp/util/debug.hh>
+
+namespace hpp {
+namespace manipulation {
+namespace steeringMethod {
+
+namespace {
+typedef core::PathPtr_t PathPtr_t;
+
+template <bool SE3>
+class FunctionFromPath : public constraints::DifferentiableFunction {
+ public:
+  FunctionFromPath(const PathPtr_t& p)
+      : DifferentiableFunction(
+            1, 1,
+            SE3 ? LiegroupSpace::R3xSO3() : LiegroupSpace::Rn(p->outputSize())),
+        path_(p) {
+    assert(!SE3 || (p->outputSize() == 7 && p->outputDerivativeSize() == 6));
+  }
+
+  const PathPtr_t& path() const { return path_; }
+
+  std::ostream& print(std::ostream& os) const {
+    return os << (SE3 ? "FunctionFromSE3Path: " : "FunctionFromPath: ")
+              << path_->timeRange().first << ", " << path_->timeRange().second;
+  }
+
+ protected:
+  void impl_compute(core::LiegroupElementRef result, vectorIn_t arg) const {
+    bool success = path_->eval(result.vector(), arg[0]);
+    if (!success) {
+      hppDout(warning, "Failed to evaluate path at param "
+                           << arg[0] << incindent << iendl << *path_
+                           << decindent);
+    }
+  }
+
+  void impl_jacobian(matrixOut_t jacobian, vectorIn_t arg) const {
+    path_->derivative(jacobian.col(0), arg[0], 1);
+  }
+
+ private:
+  PathPtr_t path_;
+};
+}  // namespace
+
+CartesianPtr_t Cartesian::create(const core::ProblemConstPtr_t& problem) {
+  CartesianPtr_t ptr(new Cartesian(problem));
+  return ptr;
+}
+
+PathPtr_t Cartesian::makePiecewiseLinearTrajectory(
+    matrixIn_t points, vectorIn_t weights) {
+  if (points.cols() != 7)
+    throw std::invalid_argument("The input matrix should have 7 columns");
+  if (weights.size() != 6)
+    throw std::invalid_argument("The weights vector should have 6 elements");
+  LiegroupSpacePtr_t se3 = LiegroupSpace::SE3();
+  core::PathVectorPtr_t path = core::PathVector::create(7, 6);
+  if (points.rows() == 1)
+    path->appendPath(core::StraightPath::create(
+        se3, points.row(0), points.row(0), interval_t(0, 0)));
+  else
+    for (size_type i = 1; i < points.rows(); ++i) {
+      value_type d = (se3->elementConstRef(points.row(i)) -
+                      se3->elementConstRef(points.row(i - 1)))
+                         .cwiseProduct(weights)
+                         .norm();
+      path->appendPath(core::StraightPath::create(
+          se3, points.row(i - 1), points.row(i), interval_t(0, d)));
+    }
+  return path;
+}
+
+void Cartesian::maxIterations(size_type iterations) {
+  constraints_->configProjector()->maxIterations(iterations);
+}
+size_type Cartesian::maxIterations() const{
+  return constraints_->configProjector()->maxIterations();
+}
+
+void Cartesian::errorThreshold(const value_type& threshold){
+    constraints_->configProjector()->errorThreshold(threshold);
+}
+
+value_type Cartesian::errorThreshold() const{
+  return constraints_->configProjector()->errorThreshold();
+}
+
+void Cartesian::trajectoryConstraint(const ImplicitPtr_t& ic) {
+  if (trajConstraint_) {
+    throw std::logic_error("Cartesian::trajectoryConstraint: trajectory constraint may be called "
+        "only once. Recreate a new instance of this class if you want to change "
+        "the constraint.");
+  }
+  trajConstraint_ = ic->copy();
+  constraints_->configProjector()->add(trajConstraint_);
+}
+
+void Cartesian::rightHandSide(const PathPtr_t& rhs, bool se3Output) {
+
+  if (se3Output)
+    rightHandSide(DifferentiableFunctionPtr_t(new FunctionFromPath<true>(rhs)),
+                  rhs->timeRange());
+  else
+    rightHandSide(DifferentiableFunctionPtr_t(new FunctionFromPath<false>(rhs)),
+                  rhs->timeRange());
+}
+
+void Cartesian::rightHandSide(const DifferentiableFunctionPtr_t& rhs,
+                              const interval_t& timeRange) {
+  if (rhs->inputSize() != 1) {
+    std::ostringstream os;
+    os << "Cartesian::rightHandSide: input space of input function should be 1 but is "
+       << rhs->inputSize() << ".";
+    throw std::logic_error(os.str().c_str());
+  }
+  trajConstraint_->rightHandSideFunction(rhs);
+  timeRange_ = timeRange;
+  rhs_ = rhs;
+}
+
+void Cartesian::checkProblem(const std::string& method) {
+  if (!trajConstraint_) {
+    std::ostringstream os;
+    os << method << ": the trajectory constraint has not been defined.";
+    throw std::logic_error(os.str().c_str());
+  }
+  if (!rhs_) {
+    std::ostringstream os;
+    os << method << ": the right hand side of the trajectory constraint has not been defined.";
+    throw std::logic_error(os.str().c_str());
+  }
+  if (constraints_->configProjector()->errorThreshold() <= 0) {
+    std::ostringstream os;
+    os << method << ": the error threshold of the numerical solver should be positive, but is "
+       << constraints_->configProjector()->errorThreshold() << ". Did you initialize it?";
+    throw std::logic_error(os.str().c_str());
+  }
+  if (constraints_->configProjector()->maxIterations() <= 0) {
+    std::ostringstream os;
+    os << method << ": the maximal number of iteration of the numerical solver should be "
+      "positive, but is "
+       << constraints_->configProjector()->errorThreshold() << ". Did you initialize it?";
+    throw std::logic_error(os.str().c_str());
+  }
+}
+
+bool Cartesian::planPath(ConfigurationIn_t q_init, PathPtr_t& result) {
+  checkProblem("Cartesian::planPath");
+  bool success = false;
+  vector_t times(nDiscreteSteps_ + 1);
+  matrix_t steps(trajConstraint_->functionPtr()->inputSize(), nDiscreteSteps_ + 1);
+
+  // Discretize definition interval of the steering method into times
+  times[0] = timeRange_.first;
+  size_type i = 1;
+  for (; i < nDiscreteSteps_; ++i)
+    times[i] = timeRange_.first +
+      (double) i * (timeRange_.second - timeRange_.first) / (double) nDiscreteSteps_;
+  times[nDiscreteSteps_] = timeRange_.second;
+
+  // For each random configuration,
+  //   - compute initial configuration of path by projecting the random
+  //     configuration (initial configuration for the first time),
+  //   - compute following samples by projecting current sample after
+  //     updating right hand side.
+  // If failure, try next random configuration.
+  // Failure can be due to
+  //   - projection,
+  //   - collision of final configuration,
+  //   - validation of path (for collision mainly).
+  constraints_->configProjector()->rightHandSideAt(times[0]);
+  // Check that initial configuration sarisfies the constraints of the
+  // problem
+  if (!constraints_->isSatisfied(q_init)) {
+    std::ostringstream os;
+    os << "Cartesian::planPath: initial configuration " << pinocchio::displayConfig(q_init)
+       << " does not satisfy the constraints of the problem.";
+    throw std::logic_error(os.str().c_str());
+  }
+  steps.col(0) = q_init;
+  success = true;
+  for (i = 1; i <= nDiscreteSteps_; ++i) {
+    constraints_->configProjector()->rightHandSideAt(times[i]);
+    steps.col(i) = steps.col(i - 1);
+    if (!constraints_->apply(steps.col(i))) {
+      success = false;
+      break;
+    }
+  }
+  // return portion of paths that was successfully projected
+  if (i > 1) {
+    result = projectedPath(times.head(i), steps.leftCols(i));
+    return success;
+  }
+  result = PathPtr_t();
+  return false;
+}
+
+Cartesian::Cartesian(const core::ProblemConstPtr_t& problem) : robot_(problem->robot()),
+    constraints_(), trajConstraint_(), rhs_(), timeRange_(), nDiscreteSteps_(20) {
+
+  if (!robot_) {
+    std::string msg("Cartesian::Cartesian: no robot in problem.");
+    throw std::logic_error(msg);
+  }
+  if (!problem->constraints() || !problem->constraints()->configProjector()) {
+    constraints_ = core::ConstraintSet::create(problem->robot(), "steeringMethod::Cartesian");
+    constraints_->addConstraint(ConfigProjector::create(problem->robot(),
+                                                        "steeringMethod::Cartesian", 0, 0));
+  } else {
+    constraints_ = HPP_DYNAMIC_PTR_CAST(core::ConstraintSet, problem->constraints()->copy());
+    assert(constraints_);
+  }
+}
+
+PathPtr_t Cartesian::projectedPath(vectorIn_t times, matrixIn_t configs) const {
+  size_type N = configs.cols();
+  if (timeRange_.first != times[0] || timeRange_.second != times[N - 1]) {
+    HPP_THROW(std::logic_error,
+              "Cartesian::planPath: Time range (" << timeRange_.first << ", " << timeRange_.second
+                             << ") does not match configuration "
+                                "times ("
+                             << times[0] << ", " << times[N - 1]);
+  }
+
+  using core::InterpolatedPath;
+  using core::InterpolatedPathPtr_t;
+
+  InterpolatedPathPtr_t path = InterpolatedPath::create(
+      robot_, configs.col(0), configs.col(N - 1), timeRange_, constraints_);
+
+  for (size_type i = 1; i < configs.cols() - 1; ++i)
+    path->insert(times[i], configs.col(i));
+
+  return path;
+}
+
+}  // namespace steeringMethod
+}  // namespace manipulation
+}  // namespace hpp

--- a/src/steering-method/cartesian.cc
+++ b/src/steering-method/cartesian.cc
@@ -26,24 +26,19 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 // DAMAGE.
 
-#include <stdexcept>
-
 #include <hpp/constraints/differentiable-function.hh>
 #include <hpp/constraints/implicit.hh>
-
 #include <hpp/core/config-projector.hh>
 #include <hpp/core/constraint-set.hh>
 #include <hpp/core/interpolated-path.hh>
 #include <hpp/core/path-vector.hh>
 #include <hpp/core/problem.hh>
 #include <hpp/core/straight-path.hh>
-
 #include <hpp/manipulation/steering-method/cartesian.hh>
-
 #include <hpp/pinocchio/configuration.hh>
 #include <hpp/pinocchio/liegroup-space.hh>
-
 #include <hpp/util/debug.hh>
+#include <stdexcept>
 
 namespace hpp {
 namespace manipulation {
@@ -94,8 +89,8 @@ CartesianPtr_t Cartesian::create(const core::ProblemConstPtr_t& problem) {
   return ptr;
 }
 
-PathPtr_t Cartesian::makePiecewiseLinearTrajectory(
-    matrixIn_t points, vectorIn_t weights) {
+PathPtr_t Cartesian::makePiecewiseLinearTrajectory(matrixIn_t points,
+                                                   vectorIn_t weights) {
   if (points.cols() != 7)
     throw std::invalid_argument("The input matrix should have 7 columns");
   if (weights.size() != 6)
@@ -120,22 +115,24 @@ PathPtr_t Cartesian::makePiecewiseLinearTrajectory(
 void Cartesian::maxIterations(size_type iterations) {
   constraints_->configProjector()->maxIterations(iterations);
 }
-size_type Cartesian::maxIterations() const{
+size_type Cartesian::maxIterations() const {
   return constraints_->configProjector()->maxIterations();
 }
 
-void Cartesian::errorThreshold(const value_type& threshold){
-    constraints_->configProjector()->errorThreshold(threshold);
+void Cartesian::errorThreshold(const value_type& threshold) {
+  constraints_->configProjector()->errorThreshold(threshold);
 }
 
-value_type Cartesian::errorThreshold() const{
+value_type Cartesian::errorThreshold() const {
   return constraints_->configProjector()->errorThreshold();
 }
 
 void Cartesian::trajectoryConstraint(const ImplicitPtr_t& ic) {
   if (trajConstraint_) {
-    throw std::logic_error("Cartesian::trajectoryConstraint: trajectory constraint may be called "
-        "only once. Recreate a new instance of this class if you want to change "
+    throw std::logic_error(
+        "Cartesian::trajectoryConstraint: trajectory constraint may be called "
+        "only once. Recreate a new instance of this class if you want to "
+        "change "
         "the constraint.");
   }
   trajConstraint_ = ic->copy();
@@ -143,7 +140,6 @@ void Cartesian::trajectoryConstraint(const ImplicitPtr_t& ic) {
 }
 
 void Cartesian::rightHandSide(const PathPtr_t& rhs, bool se3Output) {
-
   if (se3Output)
     rightHandSide(DifferentiableFunctionPtr_t(new FunctionFromPath<true>(rhs)),
                   rhs->timeRange());
@@ -156,7 +152,8 @@ void Cartesian::rightHandSide(const DifferentiableFunctionPtr_t& rhs,
                               const interval_t& timeRange) {
   if (rhs->inputSize() != 1) {
     std::ostringstream os;
-    os << "Cartesian::rightHandSide: input space of input function should be 1 but is "
+    os << "Cartesian::rightHandSide: input space of input function should be 1 "
+          "but is "
        << rhs->inputSize() << ".";
     throw std::logic_error(os.str().c_str());
   }
@@ -173,20 +170,27 @@ void Cartesian::checkProblem(const std::string& method) {
   }
   if (!rhs_) {
     std::ostringstream os;
-    os << method << ": the right hand side of the trajectory constraint has not been defined.";
+    os << method
+       << ": the right hand side of the trajectory constraint has not been "
+          "defined.";
     throw std::logic_error(os.str().c_str());
   }
   if (constraints_->configProjector()->errorThreshold() <= 0) {
     std::ostringstream os;
-    os << method << ": the error threshold of the numerical solver should be positive, but is "
-       << constraints_->configProjector()->errorThreshold() << ". Did you initialize it?";
+    os << method
+       << ": the error threshold of the numerical solver should be positive, "
+          "but is "
+       << constraints_->configProjector()->errorThreshold()
+       << ". Did you initialize it?";
     throw std::logic_error(os.str().c_str());
   }
   if (constraints_->configProjector()->maxIterations() <= 0) {
     std::ostringstream os;
-    os << method << ": the maximal number of iteration of the numerical solver should be "
-      "positive, but is "
-       << constraints_->configProjector()->errorThreshold() << ". Did you initialize it?";
+    os << method
+       << ": the maximal number of iteration of the numerical solver should be "
+          "positive, but is "
+       << constraints_->configProjector()->errorThreshold()
+       << ". Did you initialize it?";
     throw std::logic_error(os.str().c_str());
   }
 }
@@ -195,14 +199,16 @@ bool Cartesian::planPath(ConfigurationIn_t q_init, PathPtr_t& result) {
   checkProblem("Cartesian::planPath");
   bool success = false;
   vector_t times(nDiscreteSteps_ + 1);
-  matrix_t steps(trajConstraint_->functionPtr()->inputSize(), nDiscreteSteps_ + 1);
+  matrix_t steps(trajConstraint_->functionPtr()->inputSize(),
+                 nDiscreteSteps_ + 1);
 
   // Discretize definition interval of the steering method into times
   times[0] = timeRange_.first;
   size_type i = 1;
   for (; i < nDiscreteSteps_; ++i)
-    times[i] = timeRange_.first +
-      (double) i * (timeRange_.second - timeRange_.first) / (double) nDiscreteSteps_;
+    times[i] = timeRange_.first + (double)i *
+                                      (timeRange_.second - timeRange_.first) /
+                                      (double)nDiscreteSteps_;
   times[nDiscreteSteps_] = timeRange_.second;
 
   // For each random configuration,
@@ -220,7 +226,8 @@ bool Cartesian::planPath(ConfigurationIn_t q_init, PathPtr_t& result) {
   // problem
   if (!constraints_->isSatisfied(q_init)) {
     std::ostringstream os;
-    os << "Cartesian::planPath: initial configuration " << pinocchio::displayConfig(q_init)
+    os << "Cartesian::planPath: initial configuration "
+       << pinocchio::displayConfig(q_init)
        << " does not satisfy the constraints of the problem.";
     throw std::logic_error(os.str().c_str());
   }
@@ -243,19 +250,25 @@ bool Cartesian::planPath(ConfigurationIn_t q_init, PathPtr_t& result) {
   return false;
 }
 
-Cartesian::Cartesian(const core::ProblemConstPtr_t& problem) : robot_(problem->robot()),
-    constraints_(), trajConstraint_(), rhs_(), timeRange_(), nDiscreteSteps_(20) {
-
+Cartesian::Cartesian(const core::ProblemConstPtr_t& problem)
+    : robot_(problem->robot()),
+      constraints_(),
+      trajConstraint_(),
+      rhs_(),
+      timeRange_(),
+      nDiscreteSteps_(20) {
   if (!robot_) {
     std::string msg("Cartesian::Cartesian: no robot in problem.");
     throw std::logic_error(msg);
   }
   if (!problem->constraints() || !problem->constraints()->configProjector()) {
-    constraints_ = core::ConstraintSet::create(problem->robot(), "steeringMethod::Cartesian");
-    constraints_->addConstraint(ConfigProjector::create(problem->robot(),
-                                                        "steeringMethod::Cartesian", 0, 0));
+    constraints_ = core::ConstraintSet::create(problem->robot(),
+                                               "steeringMethod::Cartesian");
+    constraints_->addConstraint(ConfigProjector::create(
+        problem->robot(), "steeringMethod::Cartesian", 0, 0));
   } else {
-    constraints_ = HPP_DYNAMIC_PTR_CAST(core::ConstraintSet, problem->constraints()->copy());
+    constraints_ = HPP_DYNAMIC_PTR_CAST(core::ConstraintSet,
+                                        problem->constraints()->copy());
     assert(constraints_);
   }
 }
@@ -263,11 +276,12 @@ Cartesian::Cartesian(const core::ProblemConstPtr_t& problem) : robot_(problem->r
 PathPtr_t Cartesian::projectedPath(vectorIn_t times, matrixIn_t configs) const {
   size_type N = configs.cols();
   if (timeRange_.first != times[0] || timeRange_.second != times[N - 1]) {
-    HPP_THROW(std::logic_error,
-              "Cartesian::planPath: Time range (" << timeRange_.first << ", " << timeRange_.second
-                             << ") does not match configuration "
-                                "times ("
-                             << times[0] << ", " << times[N - 1]);
+    HPP_THROW(std::logic_error, "Cartesian::planPath: Time range ("
+                                    << timeRange_.first << ", "
+                                    << timeRange_.second
+                                    << ") does not match configuration "
+                                       "times ("
+                                    << times[0] << ", " << times[N - 1]);
   }
 
   using core::InterpolatedPath;


### PR DESCRIPTION
This PR simplifies the code. EndEffectorTrajectory steering method and path planner have been replaced by a steering method called steeringMethod::Cartesian. This steering method computes a robot path given an initial configuration and a trajectory of an end-effector using a time-varying constraint.

The path is not tested for collision and a sub-path is returned in case of failure.