### PR TITLE
[Graph] Add static method that returns transition at a parameter

### DIFF
--- a/include/hpp/manipulation/graph/graph.hh
+++ b/include/hpp/manipulation/graph/graph.hh
@@ -67,6 +67,14 @@ class HPP_MANIPULATION_DLLAPI Graph : public GraphComponent {
   static GraphPtr_t create(const std::string& name, DevicePtr_t robot,
                            const ProblemPtr_t& problem);
 
+  /// Return the edge that created the path at a given parameter
+  ///
+  /// \param path a \link hpp::core::pathVector PathVector instance,
+  /// \param param parameter along the path.
+  ///
+  /// The elements of the path vector should have been created by an edge.
+  static EdgePtr_t edgeAtParam(const core::PathVectorPtr_t& path, value_type param);
+
   GraphPtr_t self() const { return wkPtr_.lock(); }
 
   /// Create and insert a state selector inside the graph.

--- a/include/hpp/manipulation/graph/graph.hh
+++ b/include/hpp/manipulation/graph/graph.hh
@@ -73,7 +73,8 @@ class HPP_MANIPULATION_DLLAPI Graph : public GraphComponent {
   /// \param param parameter along the path.
   ///
   /// The elements of the path vector should have been created by an edge.
-  static EdgePtr_t edgeAtParam(const core::PathVectorPtr_t& path, value_type param);
+  static EdgePtr_t edgeAtParam(const core::PathVectorPtr_t& path,
+                               value_type param);
 
   GraphPtr_t self() const { return wkPtr_.lock(); }
 

--- a/include/hpp/manipulation/path-optimization/enforce-transition-semantic.hh
+++ b/include/hpp/manipulation/path-optimization/enforce-transition-semantic.hh
@@ -30,6 +30,7 @@
 #define HPP_MANIPULATION_PATHOPTIMIZATION_ENFORCE_TRANSITION_SEMANTIC_HH
 
 #include <hpp/core/path-optimizer.hh>
+#include <hpp/manipulation/deprecated.hh>
 #include <hpp/manipulation/problem.hh>
 
 namespace hpp {
@@ -63,6 +64,8 @@ class HPP_MANIPULATION_DLLAPI EnforceTransitionSemantic
  private:
   ProblemConstPtr_t problem_;
 };
+
+typedef EnforceTransitionSemantic ets HPP_MANIPULATION_DEPRECATED;
 
 /// \}
 }  // namespace pathOptimization

--- a/src/graph/graph.cc
+++ b/src/graph/graph.cc
@@ -29,7 +29,6 @@
 #include "hpp/manipulation/graph/graph.hh"
 
 #include <hpp/core/path-vector.hh>
-
 #include <hpp/manipulation/constraint-set.hh>
 #include <hpp/util/assertion.hh>
 
@@ -63,7 +62,8 @@ void Graph::init(const GraphWkPtr_t& weak, DevicePtr_t robot) {
   maxIterations_ = 20;
 }
 
-EdgePtr_t Graph::edgeAtParam(const core::PathVectorPtr_t& path, value_type param) {
+EdgePtr_t Graph::edgeAtParam(const core::PathVectorPtr_t& path,
+                             value_type param) {
   core::PathVectorPtr_t flat = core::PathVector::create(
       path->outputSize(), path->outputDerivativeSize());
   path->flatten(flat);
@@ -71,18 +71,17 @@ EdgePtr_t Graph::edgeAtParam(const core::PathVectorPtr_t& path, value_type param
   std::size_t r = flat->rankAtParam(param, unused);
   core::PathPtr_t p = flat->pathAtRank(r);
   ConstraintSetPtr_t constraint =
-    HPP_DYNAMIC_PTR_CAST(ConstraintSet, p->constraints());
+      HPP_DYNAMIC_PTR_CAST(ConstraintSet, p->constraints());
   if (!constraint) {
     HPP_THROW(std::runtime_error,
-        "Graph::edgeAtParam: path constraint is not of the expected type "
+              "Graph::edgeAtParam: path constraint is not of the expected type "
               "(hpp::manipulation::ConstraintSet)"
-        << "at param " << param
-        << " (rank: " << r << ")");
+                  << "at param " << param << " (rank: " << r << ")");
   }
   if (!constraint->edge()) {
-    HPP_THROW(std::runtime_error, "Path constraint does not contain edge information "
-              << "at param " << param
-              << " (rank: " << r << ")");
+    HPP_THROW(std::runtime_error,
+              "Path constraint does not contain edge information "
+                  << "at param " << param << " (rank: " << r << ")");
   }
   return constraint->edge();
 }

--- a/src/graph/graph.cc
+++ b/src/graph/graph.cc
@@ -28,6 +28,8 @@
 
 #include "hpp/manipulation/graph/graph.hh"
 
+#include <hpp/core/path-vector.hh>
+
 #include <hpp/manipulation/constraint-set.hh>
 #include <hpp/util/assertion.hh>
 
@@ -59,6 +61,30 @@ void Graph::init(const GraphWkPtr_t& weak, DevicePtr_t robot) {
       graph::HistogramPtr_t(new graph::StateHistogram(wkPtr_.lock())));
   errorThreshold_ = 1e-4;
   maxIterations_ = 20;
+}
+
+EdgePtr_t Graph::edgeAtParam(const core::PathVectorPtr_t& path, value_type param) {
+  core::PathVectorPtr_t flat = core::PathVector::create(
+      path->outputSize(), path->outputDerivativeSize());
+  path->flatten(flat);
+  value_type unused;
+  std::size_t r = flat->rankAtParam(param, unused);
+  core::PathPtr_t p = flat->pathAtRank(r);
+  ConstraintSetPtr_t constraint =
+    HPP_DYNAMIC_PTR_CAST(ConstraintSet, p->constraints());
+  if (!constraint) {
+    HPP_THROW(std::runtime_error,
+        "Graph::edgeAtParam: path constraint is not of the expected type "
+              "(hpp::manipulation::ConstraintSet)"
+        << "at param " << param
+        << " (rank: " << r << ")");
+  }
+  if (!constraint->edge()) {
+    HPP_THROW(std::runtime_error, "Path constraint does not contain edge information "
+              << "at param " << param
+              << " (rank: " << r << ")");
+  }
+  return constraint->edge();
 }
 
 void Graph::initialize() {

--- a/src/manipulation-planner.cc
+++ b/src/manipulation-planner.cc
@@ -46,8 +46,8 @@
 #include "hpp/manipulation/device.hh"
 #include "hpp/manipulation/graph-path-validation.hh"
 #include "hpp/manipulation/graph/edge.hh"
-#include "hpp/manipulation/graph/state.hh"
 #include "hpp/manipulation/graph/state-selector.hh"
+#include "hpp/manipulation/graph/state.hh"
 #include "hpp/manipulation/graph/statistics.hh"
 #include "hpp/manipulation/problem.hh"
 #include "hpp/manipulation/roadmap-node.hh"
@@ -167,7 +167,8 @@ StringList_t ManipulationPlanner::errorList() {
   return ret;
 }
 
-graph::Edges_t getAllEdges(const graph::StatePtr_t& from, const graph::StatePtr_t& to) {
+graph::Edges_t getAllEdges(const graph::StatePtr_t& from,
+                           const graph::StatePtr_t& to) {
   graph::Edges_t edges;
   for (graph::Neighbors_t::const_iterator it = from->neighbors().begin();
        it != from->neighbors().end(); ++it) {
@@ -181,7 +182,8 @@ graph::Edges_t getAllEdges(const graph::StatePtr_t& from, const graph::StatePtr_
 }
 
 void recomputeTransition(const core::PathPtr_t& path) {
-    ConstraintSetPtr_t c = HPP_DYNAMIC_PTR_CAST(ConstraintSet, path->constraints());
+  ConstraintSetPtr_t c =
+      HPP_DYNAMIC_PTR_CAST(ConstraintSet, path->constraints());
   if (!c) {
     hppDout(info, "No manipulation::ConstraintSet");
     return;
@@ -200,15 +202,15 @@ void recomputeTransition(const core::PathPtr_t& path) {
   if (q0_in_src && q1_in_dst)  // Nominal case
     return;
   hppDout(warning, "Transition "
-          << i
-          << ". "
-          "\nsrc="
-          << src->name() << "\ndst=" << dst->name()
-          << "\nq0_in_src=" << q0_in_src << "\nq1_in_src="
-          << q1_in_src << "\nq0_in_dst=" << q0_in_dst
-          << "\nq1_in_dst=" << q1_in_dst << setpyformat
-          << "\nq0=" << one_line(q0) << "\nq1=" << one_line(q1)
-          << unsetpyformat << "\nTrying with state.");
+                       << i
+                       << ". "
+                          "\nsrc="
+                       << src->name() << "\ndst=" << dst->name()
+                       << "\nq0_in_src=" << q0_in_src << "\nq1_in_src="
+                       << q1_in_src << "\nq0_in_dst=" << q0_in_dst
+                       << "\nq1_in_dst=" << q1_in_dst << setpyformat
+                       << "\nq0=" << one_line(q0) << "\nq1=" << one_line(q1)
+                       << unsetpyformat << "\nTrying with state.");
 
   graph::StatePtr_t from, to;
   if (q0_in_dst && q1_in_src) {  // Reversed from nominal case
@@ -243,15 +245,15 @@ void recomputeTransition(const core::PathPtr_t& path) {
     }
   }
   hppDout(warning, "Unable to find a suitable transition for "
-          << i
-          << ". "
-          "\nsrc="
-          << src->name() << "\ndst=" << dst->name()
-          << "\nq0_in_src=" << q0_in_src << "\nq1_in_src="
-          << q1_in_src << "\nq0_in_dst=" << q0_in_dst
-          << "\nq1_in_dst=" << q1_in_dst << setpyformat
-          << "\nq0=" << one_line(q0) << "\nq1=" << one_line(q1)
-          << unsetpyformat << "\nTrying with state.");
+                       << i
+                       << ". "
+                          "\nsrc="
+                       << src->name() << "\ndst=" << dst->name()
+                       << "\nq0_in_src=" << q0_in_src << "\nq1_in_src="
+                       << q1_in_src << "\nq0_in_dst=" << q0_in_dst
+                       << "\nq1_in_dst=" << q1_in_dst << setpyformat
+                       << "\nq0=" << one_line(q0) << "\nq1=" << one_line(q1)
+                       << unsetpyformat << "\nTrying with state.");
 
   graph::StatePtr_t state = c->edge()->state();
   // Check that a path from dst to to exists.
@@ -264,7 +266,9 @@ void recomputeTransition(const core::PathPtr_t& path) {
     return;
   } else {
     std::ostringstream os;
-    os << "ManipulationPlanner::oneStep: Unable to find a suitable transition for " << *path;
+    os << "ManipulationPlanner::oneStep: Unable to find a suitable transition "
+          "for "
+       << *path;
     throw std::logic_error(os.str().c_str());
   }
 }

--- a/src/manipulation-planner.cc
+++ b/src/manipulation-planner.cc
@@ -46,6 +46,7 @@
 #include "hpp/manipulation/device.hh"
 #include "hpp/manipulation/graph-path-validation.hh"
 #include "hpp/manipulation/graph/edge.hh"
+#include "hpp/manipulation/graph/state.hh"
 #include "hpp/manipulation/graph/state-selector.hh"
 #include "hpp/manipulation/graph/statistics.hh"
 #include "hpp/manipulation/problem.hh"
@@ -166,6 +167,108 @@ StringList_t ManipulationPlanner::errorList() {
   return ret;
 }
 
+graph::Edges_t getAllEdges(const graph::StatePtr_t& from, const graph::StatePtr_t& to) {
+  graph::Edges_t edges;
+  for (graph::Neighbors_t::const_iterator it = from->neighbors().begin();
+       it != from->neighbors().end(); ++it) {
+    if (it->second->stateTo() == to) edges.push_back(it->second);
+  }
+  for (graph::Edges_t::const_iterator it = from->hiddenNeighbors().begin();
+       it != from->hiddenNeighbors().end(); ++it) {
+    if ((*it)->stateTo() == to) edges.push_back(*it);
+  }
+  return edges;
+}
+
+void recomputeTransition(const core::PathPtr_t& path) {
+    ConstraintSetPtr_t c = HPP_DYNAMIC_PTR_CAST(ConstraintSet, path->constraints());
+  if (!c) {
+    hppDout(info, "No manipulation::ConstraintSet");
+    return;
+  }
+  Configuration_t q0 = path->initial();
+  Configuration_t q1 = path->end();
+  graph::StatePtr_t src = c->edge()->stateFrom();
+  graph::StatePtr_t dst = c->edge()->stateTo();
+  if (src == dst) return;
+
+  bool q0_in_src = src->contains(q0);
+  bool q1_in_src = src->contains(q1);
+  bool q0_in_dst = dst->contains(q0);
+  bool q1_in_dst = dst->contains(q1);
+
+  if (q0_in_src && q1_in_dst)  // Nominal case
+    return;
+  hppDout(warning, "Transition "
+          << i
+          << ". "
+          "\nsrc="
+          << src->name() << "\ndst=" << dst->name()
+          << "\nq0_in_src=" << q0_in_src << "\nq1_in_src="
+          << q1_in_src << "\nq0_in_dst=" << q0_in_dst
+          << "\nq1_in_dst=" << q1_in_dst << setpyformat
+          << "\nq0=" << one_line(q0) << "\nq1=" << one_line(q1)
+          << unsetpyformat << "\nTrying with state.");
+
+  graph::StatePtr_t from, to;
+  if (q0_in_dst && q1_in_src) {  // Reversed from nominal case
+    from = dst;
+    to = src;
+  } else if (q0_in_dst && q1_in_dst) {
+    from = dst;
+    to = dst;
+  } else if (q0_in_src && q1_in_src) {
+    from = src;
+    to = src;
+  } else if (q0_in_src) {  // Keep same transition
+    return;
+  } else if (q0_in_dst) {  // Reverse current transition
+    from = dst;
+    to = src;
+  } else if (q1_in_src) {  // Keep same transition
+    return;
+  } else if (q1_in_dst) {  // Reverse current transition
+    from = dst;
+    to = src;
+  }
+  if (from && to) {
+    // Check that a path from dst to to exists.
+    graph::Edges_t transitions = getAllEdges(from, to);
+    if (transitions.size() >= 1) {
+      if (transitions.size() > 1) {
+        hppDout(info, "More than one transition...");
+      }
+      c->edge(transitions[0]);
+      return;
+    }
+  }
+  hppDout(warning, "Unable to find a suitable transition for "
+          << i
+          << ". "
+          "\nsrc="
+          << src->name() << "\ndst=" << dst->name()
+          << "\nq0_in_src=" << q0_in_src << "\nq1_in_src="
+          << q1_in_src << "\nq0_in_dst=" << q0_in_dst
+          << "\nq1_in_dst=" << q1_in_dst << setpyformat
+          << "\nq0=" << one_line(q0) << "\nq1=" << one_line(q1)
+          << unsetpyformat << "\nTrying with state.");
+
+  graph::StatePtr_t state = c->edge()->state();
+  // Check that a path from dst to to exists.
+  graph::Edges_t transitions = getAllEdges(state, state);
+  if (transitions.size() >= 1) {
+    if (transitions.size() > 1) {
+      hppDout(info, "More than one transition...");
+    }
+    c->edge(transitions[0]);
+    return;
+  } else {
+    std::ostringstream os;
+    os << "ManipulationPlanner::oneStep: Unable to find a suitable transition for " << *path;
+    throw std::logic_error(os.str().c_str());
+  }
+}
+
 void ManipulationPlanner::oneStep() {
   HPP_START_TIMECOUNTER(oneStep);
 
@@ -207,6 +310,7 @@ void ManipulationPlanner::oneStep() {
       HPP_DISPLAY_LAST_TIMECOUNTER(extend);
       // Insert new path to q_near in roadmap
       if (pathIsValid) {
+        recomputeTransition(path);
         value_type t_final = path->timeRange().second;
         if (t_final != path->timeRange().first) {
           bool success;


### PR DESCRIPTION
along a path vector.
Elements of the path vector should have been produced by a transition.

Make optimizer EnforceTransitionSemantics deprecated.