### PR TITLE
Reintroduce EnforceTransitionSemantic and document class

### DIFF
--- a/include/hpp/manipulation/path-optimization/enforce-transition-semantic.hh
+++ b/include/hpp/manipulation/path-optimization/enforce-transition-semantic.hh
@@ -43,27 +43,30 @@ using hpp::core::PathVector;
 
 /// Recompute the transition relative to each element of the path vector
 ///
-/// When executing a sequence of direct paths on a real robot, it is useful to know which
-/// transition of the graph each direct path corresponds to. For example, in a manipulation
-/// motion, before grasping an object, the robot needs to open the gripper. This information
-/// is contained in the transition that leads to a pregrasp waypoint state. The direct path
-/// should therefore have access to the transition.
+/// When executing a sequence of direct paths on a real robot, it is useful to
+/// know which transition of the graph each direct path corresponds to. For
+/// example, in a manipulation motion, before grasping an object, the robot
+/// needs to open the gripper. This information is contained in the transition
+/// that leads to a pregrasp waypoint state. The direct path should therefore
+/// have access to the transition.
 ///
-/// The information is stored in the \link hpp::manipulation::ConstraintSet constraint set \endlink
-/// of the path and is accessible via method \link hpp::manipulation::ConstraintSet::edge edge
+/// The information is stored in the \link hpp::manipulation::ConstraintSet
+/// constraint set \endlink of the path and is accessible via method \link
+/// hpp::manipulation::ConstraintSet::edge edge
 /// \endlink.
 ///
-/// If the path vector is produced by a manipulation planner, each direct path has been created
-/// by a transition. However, the path may later be cut by random shortcut or due to collision and
-/// the associated transition become irrelevant. For example if a path is created by a transition
-/// that leads to a pre-grasp, and cut due to a collision, the path does not reach the target
+/// If the path vector is produced by a manipulation planner, each direct path
+/// has been created by a transition. However, the path may later be cut by
+/// random shortcut or due to collision and the associated transition become
+/// irrelevant. For example if a path is created by a transition that leads to a
+/// pre-grasp, and cut due to a collision, the path does not reach the target
 /// state and the relevant transition is not the one that built the path.
 ///
-/// This class takes a \link hpp::core::PathVector path vector \endlink as input an relabel
-/// each direct path with the correct transition.
+/// This class takes a \link hpp::core::PathVector path vector \endlink as input
+/// an relabel each direct path with the correct transition.
 ///
-/// \pre The path should have been created by a manipulation planning algorithm: in other
-/// words, the constraint set of each direct path should be of type
+/// \pre The path should have been created by a manipulation planning algorithm:
+/// in other words, the constraint set of each direct path should be of type
 /// hpp::manipulation::ConstraintSet.
 class HPP_MANIPULATION_DLLAPI EnforceTransitionSemantic
     : public core::PathOptimizer {

--- a/include/hpp/manipulation/path-optimization/enforce-transition-semantic.hh
+++ b/include/hpp/manipulation/path-optimization/enforce-transition-semantic.hh
@@ -30,7 +30,6 @@
 #define HPP_MANIPULATION_PATHOPTIMIZATION_ENFORCE_TRANSITION_SEMANTIC_HH
 
 #include <hpp/core/path-optimizer.hh>
-#include <hpp/manipulation/deprecated.hh>
 #include <hpp/manipulation/problem.hh>
 
 namespace hpp {
@@ -64,8 +63,6 @@ class HPP_MANIPULATION_DLLAPI EnforceTransitionSemantic
  private:
   ProblemConstPtr_t problem_;
 };
-
-typedef EnforceTransitionSemantic ets HPP_MANIPULATION_DEPRECATED;
 
 /// \}
 }  // namespace pathOptimization

--- a/include/hpp/manipulation/path-optimization/enforce-transition-semantic.hh
+++ b/include/hpp/manipulation/path-optimization/enforce-transition-semantic.hh
@@ -41,6 +41,30 @@ using hpp::core::PathVector;
 /// \addtogroup path_optimization
 /// \{
 
+/// Recompute the transition relative to each element of the path vector
+///
+/// When executing a sequence of direct paths on a real robot, it is useful to know which
+/// transition of the graph each direct path corresponds to. For example, in a manipulation
+/// motion, before grasping an object, the robot needs to open the gripper. This information
+/// is contained in the transition that leads to a pregrasp waypoint state. The direct path
+/// should therefore have access to the transition.
+///
+/// The information is stored in the \link hpp::manipulation::ConstraintSet constraint set \endlink
+/// of the path and is accessible via method \link hpp::manipulation::ConstraintSet::edge edge
+/// \endlink.
+///
+/// If the path vector is produced by a manipulation planner, each direct path has been created
+/// by a transition. However, the path may later be cut by random shortcut or due to collision and
+/// the associated transition become irrelevant. For example if a path is created by a transition
+/// that leads to a pre-grasp, and cut due to a collision, the path does not reach the target
+/// state and the relevant transition is not the one that built the path.
+///
+/// This class takes a \link hpp::core::PathVector path vector \endlink as input an relabel
+/// each direct path with the correct transition.
+///
+/// \pre The path should have been created by a manipulation planning algorithm: in other
+/// words, the constraint set of each direct path should be of type
+/// hpp::manipulation::ConstraintSet.
 class HPP_MANIPULATION_DLLAPI EnforceTransitionSemantic
     : public core::PathOptimizer {
  public:

--- a/src/manipulation-planner.cc
+++ b/src/manipulation-planner.cc
@@ -47,7 +47,6 @@
 #include "hpp/manipulation/graph-path-validation.hh"
 #include "hpp/manipulation/graph/edge.hh"
 #include "hpp/manipulation/graph/state-selector.hh"
-#include "hpp/manipulation/graph/state.hh"
 #include "hpp/manipulation/graph/statistics.hh"
 #include "hpp/manipulation/problem.hh"
 #include "hpp/manipulation/roadmap-node.hh"
@@ -167,112 +166,6 @@ StringList_t ManipulationPlanner::errorList() {
   return ret;
 }
 
-graph::Edges_t getAllEdges(const graph::StatePtr_t& from,
-                           const graph::StatePtr_t& to) {
-  graph::Edges_t edges;
-  for (graph::Neighbors_t::const_iterator it = from->neighbors().begin();
-       it != from->neighbors().end(); ++it) {
-    if (it->second->stateTo() == to) edges.push_back(it->second);
-  }
-  for (graph::Edges_t::const_iterator it = from->hiddenNeighbors().begin();
-       it != from->hiddenNeighbors().end(); ++it) {
-    if ((*it)->stateTo() == to) edges.push_back(*it);
-  }
-  return edges;
-}
-
-void recomputeTransition(const core::PathPtr_t& path) {
-  ConstraintSetPtr_t c =
-      HPP_DYNAMIC_PTR_CAST(ConstraintSet, path->constraints());
-  if (!c) {
-    hppDout(info, "No manipulation::ConstraintSet");
-    return;
-  }
-  Configuration_t q0 = path->initial();
-  Configuration_t q1 = path->end();
-  graph::StatePtr_t src = c->edge()->stateFrom();
-  graph::StatePtr_t dst = c->edge()->stateTo();
-  if (src == dst) return;
-
-  bool q0_in_src = src->contains(q0);
-  bool q1_in_src = src->contains(q1);
-  bool q0_in_dst = dst->contains(q0);
-  bool q1_in_dst = dst->contains(q1);
-
-  if (q0_in_src && q1_in_dst)  // Nominal case
-    return;
-  hppDout(warning, "Transition "
-                       << i
-                       << ". "
-                          "\nsrc="
-                       << src->name() << "\ndst=" << dst->name()
-                       << "\nq0_in_src=" << q0_in_src << "\nq1_in_src="
-                       << q1_in_src << "\nq0_in_dst=" << q0_in_dst
-                       << "\nq1_in_dst=" << q1_in_dst << setpyformat
-                       << "\nq0=" << one_line(q0) << "\nq1=" << one_line(q1)
-                       << unsetpyformat << "\nTrying with state.");
-
-  graph::StatePtr_t from, to;
-  if (q0_in_dst && q1_in_src) {  // Reversed from nominal case
-    from = dst;
-    to = src;
-  } else if (q0_in_dst && q1_in_dst) {
-    from = dst;
-    to = dst;
-  } else if (q0_in_src && q1_in_src) {
-    from = src;
-    to = src;
-  } else if (q0_in_src) {  // Keep same transition
-    return;
-  } else if (q0_in_dst) {  // Reverse current transition
-    from = dst;
-    to = src;
-  } else if (q1_in_src) {  // Keep same transition
-    return;
-  } else if (q1_in_dst) {  // Reverse current transition
-    from = dst;
-    to = src;
-  }
-  if (from && to) {
-    // Check that a path from dst to to exists.
-    graph::Edges_t transitions = getAllEdges(from, to);
-    if (transitions.size() >= 1) {
-      if (transitions.size() > 1) {
-        hppDout(info, "More than one transition...");
-      }
-      c->edge(transitions[0]);
-      return;
-    }
-  }
-  hppDout(warning, "Unable to find a suitable transition for "
-                       << i
-                       << ". "
-                          "\nsrc="
-                       << src->name() << "\ndst=" << dst->name()
-                       << "\nq0_in_src=" << q0_in_src << "\nq1_in_src="
-                       << q1_in_src << "\nq0_in_dst=" << q0_in_dst
-                       << "\nq1_in_dst=" << q1_in_dst << setpyformat
-                       << "\nq0=" << one_line(q0) << "\nq1=" << one_line(q1)
-                       << unsetpyformat << "\nTrying with state.");
-
-  graph::StatePtr_t state = c->edge()->state();
-  // Check that a path from dst to to exists.
-  graph::Edges_t transitions = getAllEdges(state, state);
-  if (transitions.size() >= 1) {
-    if (transitions.size() > 1) {
-      hppDout(info, "More than one transition...");
-    }
-    c->edge(transitions[0]);
-    return;
-  } else {
-    std::ostringstream os;
-    os << "ManipulationPlanner::oneStep: Unable to find a suitable transition "
-          "for "
-       << *path;
-    throw std::logic_error(os.str().c_str());
-  }
-}
-
 void ManipulationPlanner::oneStep() {
   HPP_START_TIMECOUNTER(oneStep);
 
@@ -314,7 +207,6 @@ void ManipulationPlanner::oneStep() {
       HPP_DISPLAY_LAST_TIMECOUNTER(extend);
       // Insert new path to q_near in roadmap
       if (pathIsValid) {
-        recomputeTransition(path);
         value_type t_final = path->timeRange().second;
         if (t_final != path->timeRange().first) {
           bool success;

--- a/src/path-optimization/enforce-transition-semantic.cc
+++ b/src/path-optimization/enforce-transition-semantic.cc
@@ -67,7 +67,7 @@ PathVectorPtr_t EnforceTransitionSemantic::optimize(
 
   ConstraintSetPtr_t c;
   for (std::size_t i = 0; i < input->numberPaths(); ++i) {
-    PathPtr_t current = input->pathAtRank(i);
+    PathPtr_t current = input->pathAtRank(i)->copy();
     output->appendPath(current);
     c = HPP_DYNAMIC_PTR_CAST(ConstraintSet, current->constraints());
     if (!c) {


### PR DESCRIPTION
Correctly labeling each direct path of a path vector resulting from a manipulation planning algorithm turns out to be
more difficult to achieve in the path planning algorithm.